### PR TITLE
Remove Reference to User ID from 'Your Filings' Page

### DIFF
--- a/templates/includes/transactions.tx
+++ b/templates/includes/transactions.tx
@@ -93,7 +93,7 @@
                                                   <div id="process-spinner" class="process-spinner"></div>
                                                   <span id="process-status" class="process-status">Status: in-progress</span>
                                                 </div>
-                                                <input type="hidden" id="document-data" data-resource-url="<% $transaction.links.self %>" data-resource-id="<% $filing.value.links.resource %>" data-content-type="text/html" data-document-type="text/html" data-user-id="<% $c.user_id %>"/>
+                                                <input type="hidden" id="document-data" data-resource-url="<% $transaction.links.self %>" data-resource-id="<% $filing.value.links.resource %>" data-content-type="text/html" data-document-type="text/html"/>
                                               </div>
                                           % }
                                           % }
@@ -118,7 +118,7 @@
                                                   <div id="process-spinner" class="process-spinner"></div>
                                                   <span id="process-status" class="process-status">Status: in-progress</span>
                                                 </div>
-                                                <input type="hidden" id="document-data" data-resource-url="<% $transaction.links.self %>" data-resource-id="<% $filing.value.links.resource %>" data-content-type="text/html" data-document-type="text/html" data-user-id="<% $c.user_id %>"/>
+                                                <input type="hidden" id="document-data" data-resource-url="<% $transaction.links.self %>" data-resource-id="<% $filing.value.links.resource %>" data-content-type="text/html" data-document-type="text/html"/>
                                               </div>
                                           % }
                                         % }
@@ -164,7 +164,7 @@
                                                   <div id="process-spinner" class="process-spinner"></div>
                                                   <span id="process-status" class="process-status">Status: in-progress</span>
                                                 </div>
-                                                <input type="hidden" id="document-data" data-resource-url="<% $transaction.links.self %>" data-resource-id="<% $filing.value.links.resource %>" data-content-type="text/html" data-document-type="text/html" data-user-id="<% $c.user_id %>"/>
+                                                <input type="hidden" id="document-data" data-resource-url="<% $transaction.links.self %>" data-resource-id="<% $filing.value.links.resource %>" data-content-type="text/html" data-document-type="text/html"/>
                                               </div>
                                             % }
                                           % }


### PR DESCRIPTION
Removal reference to user ID from the 'Your Filings' page so this internal property is not exposed in the javascript.

Resolves [FAPI-2078](https://companieshouse.atlassian.net/browse/FAPI-2078)