### PR TITLE
Fix cpanfile comment with correct dependency name

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -3,7 +3,7 @@
 # XXX unlike the rest of this file, the order in this
 # section is important.
 
-requires 'Mojo::Redis', '==1.02'; # Needs to be before Mojolicious
+requires 'Mojo::Redis', '==1.02'; # Needs to be before MojoX::Plugin::AnyCache
 requires 'Log::Log4perl', '==1.49'; # Needs to be before CH::Perl
 requires 'Log::Log4perl::Appender::Fluent', '==0.04'; # Needs to be before CH::Perl
 requires 'AnyEvent', '==7.12';


### PR DESCRIPTION
`MojoX::Plugin::AnyCache` depends on an unversioned `Mojo::Redis` dependency, meaning the latest version available will be used. Recent version of `Mojo::Redis` have introduced an explicit dependecy on a version of `Mojolicious` greater than or equal to `7.30` (see https://github.com/jhthorsen/mojo-redis/blob/master/cpanfile#L2). During dependency resolution, this will cause a version of Mojolicious that satisfies this dependency to be installed (currently `7.85`) which does not match the declared version in the cpanfile for this project, hence causing runtime failures due to the removal of expected subroutines.

By adding an explicit versioned dependency of `Mojo::Redis` we ensure that the declared version of `Mojolicious` in the `cpanfile` is correctly resolved (version `5.47`).

