### PR TITLE
remove references to unused config item disable_download_xhtml_link

### DIFF
--- a/appconfig.yml
+++ b/appconfig.yml
@@ -93,8 +93,6 @@ feature:
 
 image_service_start_date: <IMAGE_SERVICE_START_DATE>
 
-disable_download_xhtml_link: <DISABLE_DOWNLOAD_XHTML_LINK>
-
 recently_filed_days: <RECENTLY_FILED_DAYS>
 
 unavailable_date: <UNAVAILABLE_DATE>

--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -47,11 +47,6 @@ sub view {
     $self->stash->{image_service_active} = $self->can_view_images;
     # FIXME: ^^^ Remove this when Doc API goes live (and in template) ^^^
 
-    # FIXME: vvv Remove this when XBRL is working (and in template) vvv
-    my $disable_download_xhtml_link = $self->config->{disable_download_xhtml_link} || 0;
-    $self->stash(disable_download_xhtml_link => $disable_download_xhtml_link);
-    # FIXME: ^^^ Remove this when XBRL is working (and in template) ^^^
-
     # FIXME: remove this when confirmation-statement goes live - also in template
     my $confirmation_statement_available_date = $self->config->{confirmation_statement_available_date} || '2016-06-30';
 


### PR DESCRIPTION
flag is not used for any functional purpose so removing to avoid confusion going forwards