### PR TITLE
Add transaction reprocessing functionality to admin site

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -11,7 +11,7 @@ requires 'Mojolicious', '==5.47';
 requires 'Moose', '==2.1402';
 
 requires 'CH::MojoX::Administration::Plugin', '==0.35';
-requires 'Net::CompaniesHouse::Admin', '==0.35'
+requires 'Net::CompaniesHouse::Admin', '==0.36'
 requires 'Net::CompaniesHouse', '==0.65';
 requires 'CH::MojoX::Plugin::API', '==0.40';
 requires 'CH::MojoX::Plugin::Config', '==0.31';

--- a/lib/ChGovUk/Controllers/Admin/Transaction.pm
+++ b/lib/ChGovUk/Controllers/Admin/Transaction.pm
@@ -240,6 +240,7 @@ sub transaction_json {
 
     $self->_get_new_transaction($delay, $delay->begin(0));
 }
+
 #-------------------------------------------------------------------------------
 
 sub transaction_reprocess {

--- a/lib/ChGovUk/Controllers/Admin/Transaction.pm
+++ b/lib/ChGovUk/Controllers/Admin/Transaction.pm
@@ -242,6 +242,47 @@ sub transaction_json {
 }
 #-------------------------------------------------------------------------------
 
+sub transaction_reprocess {
+    my ($self) = @_;
+    
+    $self->render_later;
+    
+    my $transaction_id = $self->stash('transaction_number');
+    
+    $self->ch_api->private->transactions($transaction_id)->reprocess->create->on(
+        success => sub {
+            my ($api, $tx) = @_;
+            
+            return $self->render;
+        },
+        failure => sub {
+            my ($api, $tx) = @_;
+            my $error_code = $tx->error->{code} // 0;
+            my $error_message = $tx->error->{message};
+            
+            my $message;
+            
+            if (defined $error_code and $error_code == 403) {
+                $message = sprintf 'Transaction [%s] - Failed to reprocess non-closed transaction [%s]: [%s]', $transaction_id, $error_code, $error_message;
+            } else {
+                $message = sprintf 'Transaction [%s] - Failure occurred reprocessing transaction [%s]: [%s]', $transaction_id, $error_code, $error_message;
+            }
+            
+            error $message [ADMIN TRANSACTION_REPROCESS];
+            return $self->render_exception($message);
+        },
+        error => sub {
+            my ($api, $error) = @_;
+
+            my $message = sprintf 'Transaction [%s] - Error occurred reprocessing transaction: [%s]', $transaction_id, $error;
+            
+            error $message [ADMIN TRANSACTION_REPROCESS];
+            return $self->render_exception($message);
+        }
+    )->execute;
+}
+
+#-------------------------------------------------------------------------------
 
 sub resource_json {
     my ($self) = @_;

--- a/lib/ChGovUk/Plugins/Admin/Routes.pm
+++ b/lib/ChGovUk/Plugins/Admin/Routes.pm
@@ -28,7 +28,8 @@ sub register {
     $admin_route->get('/transactions/:transaction_number')->to('admin-transaction#filing');
     $admin_route->get('/company/:company_number/transactions')->name('admin_transaction_by_company_number')->to('admin-transaction#search_by_company_number');
     $admin_route->get('/view_json')->name('admin_transaction_resource_details')->to('admin-transaction#submission_json');
-    $transaction->get ('/details')->name('admin_transaction_details')->to('admin-transaction#transaction_json');
+    $transaction->get('/details')->name('admin_transaction_details')->to('admin-transaction#transaction_json');
+    $transaction->post('/reprocess')->name('admin_transaction_reprocess')->to('admin-transaction#transaction_reprocess');
 
     my $filing = $transaction->route('/:barcode');
     $filing->get ('/email')->name('admin_email_view')->to('admin-transaction#email_confirm');

--- a/templates/admin/transaction/transaction_reprocess.html.tx
+++ b/templates/admin/transaction/transaction_reprocess.html.tx
@@ -1,0 +1,11 @@
+% cascade base {title => 'Transaction reprocess request', searchpage => 1, classes=>"search ancillary", disable_header_search => 1}
+
+% around content -> {
+<a class="link-back" id="back-button" href="javascript:history.back()">Back</a>
+
+<div class="inner-block">
+    % include includes::page_header {title => $title}
+
+    Transaction <% $transaction_number %> will be reprocessed.
+</div>
+% }

--- a/templates/includes/transactions.tx
+++ b/templates/includes/transactions.tx
@@ -37,7 +37,7 @@
 
                         <form method="post" action="<% $c.url_for('admin_transaction_reprocess', transaction_number => $transaction.id) %>">
                             <div class="form-group">
-                                <input type="submit" id="reprocess" name="reprocess" class="admin-link" value="Reprocess transaction" class="button">
+                                <input type="submit" id="reprocess" name="reprocess" class="admin-link" value="Reprocess transaction">
                             </div>
                         </form>
                         

--- a/templates/includes/transactions.tx
+++ b/templates/includes/transactions.tx
@@ -37,7 +37,7 @@
 
                         <form method="post" action="<% $c.url_for('admin_transaction_reprocess', transaction_number => $transaction.id) %>">
                             <div class="form-group">
-                                <input type="submit" id="reprocess" name="reprocess" value="Reprocess transaction" class="button">
+                                <input type="submit" id="reprocess" name="reprocess" class="admin-link" value="Reprocess transaction" class="button">
                             </div>
                         </form>
                         

--- a/templates/includes/transactions.tx
+++ b/templates/includes/transactions.tx
@@ -30,8 +30,17 @@
                     % }
 
                     % if $c.can_do('/admin/transaction-lookup') {
+                        <a class="admin-link" id="view-transaction-<% $~transaction %>" href="<% $c.url_for('admin_transaction_details', transaction_number => $transaction.id) %>"> View transaction</a>
+                    % }
+                    
+                    % if $c.can_do('/admin/transaction-reprocess') && $transaction.status == "closed" {
 
-                        <td><a class="admin-link" id="view-transaction-<% $~transaction %>" href="<% $c.url_for('admin_transaction_details', transaction_number => $transaction.id) %>"> View transaction</a></td>
+                        <form method="post" action="<% $c.url_for('admin_transaction_reprocess', transaction_number => $transaction.id) %>">
+                            <div class="form-group">
+                                <input type="submit" id="reprocess" name="reprocess" value="Reprocess transaction" class="button">
+                            </div>
+                        </form>
+                        
                     % }
                 </div>
                 <div class="column-third column-reference" id="reference-number-<% $~transaction.count %>">


### PR DESCRIPTION
ℹ️ The changes here are part of a larger effort to introduce transaction reprocessing to the admin site.

A 'Reprocess transaction' button has been added to closed transactions on the admin site to permit users with the correct role to initiate transaction reprocessing.

**Related pull-requests:**
* https://github.com/companieshouse/account.ch.gov.uk/pull/300
* https://github.com/companieshouse/transactions.api.ch.gov.uk/pull/87
* https://github.com/companieshouse/Net-CompaniesHouse-Admin/pull/8
* https://github.com/companieshouse/cdn.ch.gov.uk/pull/274