### PR TITLE
Refactor save and resume support

### DIFF
--- a/appconfig.yml
+++ b/appconfig.yml
@@ -1,6 +1,7 @@
 ---
+
 base:
-  url: <BASE_URL>
+  url: <CHS_URL>
 
 api:
   url: <ERIC_LOCAL_URL>

--- a/appconfig.yml
+++ b/appconfig.yml
@@ -1,7 +1,7 @@
 ---
 
 base:
-  url: <CHS_URL>
+  url: <BASE_URL>
 
 api:
   url: <ERIC_LOCAL_URL>

--- a/cpanfile
+++ b/cpanfile
@@ -51,3 +51,4 @@ requires 'Readonly', '==2.00';
 
 test_requires 'CH::Test', '==0.32';
 test_requires 'Test::Differences', '==0.63';
+test_requires 'Test::Exception', '==0.43';

--- a/lib/ChGovUk/Controllers/Admin/User/Filings.pm
+++ b/lib/ChGovUk/Controllers/Admin/User/Filings.pm
@@ -80,7 +80,7 @@ sub _build_resume_link {
     my $transaction_id = $transaction->{id};
     my $encoded_resume_link = encode_base64url($resume_link);
     
-    $transaction->{resume_link} = "/user/transactions/" . $transaction_id . "/resume?id=" . $encoded_resume_link;
+    $transaction->{resume_link} = "/user/transactions/" . $transaction_id . "/resume?link=" . $encoded_resume_link;
     return;
 }
 

--- a/lib/ChGovUk/Controllers/Admin/User/Filings.pm
+++ b/lib/ChGovUk/Controllers/Admin/User/Filings.pm
@@ -35,8 +35,8 @@ sub list {
                     $doc->{closed_at_date} = CH::Util::DateHelper->isodate_as_string($doc->{closed_at});
                     $doc->{closed_at_time} = CH::Util::DateHelper->isotime_as_string($doc->{closed_at})->strftime("%l:%M%P");
                 }
-                if ($doc->{status} eq "open" && $doc->{links}->{resume}) {
-                   $self->_build_resume_link($doc, $doc->{links}->{resume});
+                if ($doc->{status} eq "open" && $doc->{resume_journey_uri}) {
+                   $self->_build_resume_link($doc, $doc->{resume_journey_uri});
                 }
             }
 

--- a/lib/ChGovUk/Controllers/Admin/User/Filings.pm
+++ b/lib/ChGovUk/Controllers/Admin/User/Filings.pm
@@ -6,7 +6,6 @@ use CH::Perl;
 use CH::Util::Pager;
 use CH::Util::DateHelper;
 use POSIX qw(strftime);
-use Digest::SHA qw(sha1);
 use MIME::Base64 qw(encode_base64url);
 
 #-------------------------------------------------------------------------------
@@ -79,9 +78,9 @@ sub _build_resume_link {
     my ($self, $transaction, $resume_link) = @_;
     
     my $transaction_id = $transaction->{id};
-    my $encoded_resource_key = encode_base64url(sha1($resume_link));
+    my $encoded_resume_link = encode_base64url($resume_link);
     
-    $transaction->{resume_link} = "/user/transactions/" . $transaction_id . "/resume?id=" . $encoded_resource_key;
+    $transaction->{resume_link} = "/user/transactions/" . $transaction_id . "/resume?id=" . $encoded_resume_link;
     return;
 }
 

--- a/lib/ChGovUk/Controllers/User/Transactions/Resume.pm
+++ b/lib/ChGovUk/Controllers/User/Transactions/Resume.pm
@@ -9,132 +9,48 @@ use POSIX qw(strftime);
 use Mojo::IOLoop::Delay;
 use Digest::SHA qw(sha1);
 use MIME::Base64 qw(encode_base64url);
-use Data::Dumper;
 
 #-------------------------------------------------------------------------------
 sub resume {
     my ($self) = @_;
-
+    
+    $self->render_later;
+    
     my $encoded_id = $self->param('id');
-
+    
     $self->ch_api->transactions($self->stash('transaction_number'))->get->on(
         success => sub {
             my ($api, $tx) = @_;
-                my $transaction = $tx->success->json;
-
-                my $resource_and_id_match = 0;
-
-                for my $resource (  keys %{$transaction->{resources}}) {
-                    if ( encode_base64url(sha1($resource)) eq $encoded_id){ 
-                        $resource_and_id_match = 1;
-                        $self->_build_resume_link($transaction, $transaction->{resources}->{$resource} );
-                        last;
-                    }
-                }
-                if ( $resource_and_id_match eq  0) {
-                    error "None of the resource keys could be matched with provided encoded id";
-                    $self->render_not_found;
-                }
+            
+            my $transaction = $tx->success->json;
+            
+            my $resume_link = $transaction->{links}->{resume};
+            
+            if (encode_base64url(sha1($resume_link)) ne $encoded_id) {
+                error "The transaction resume link does not match the encoded id";
+                $self->render_not_found;
+            }
+            
+            # TODO Render redirect confirmation for external links
+            
+            $self->redirect_to($resume_link);
         },
         failure => sub {
             my ($api, $tx) = @_;
+            
             my ($error_message, $error_code) = ($tx->error->{message}, $tx->error->{code});
-                my $message = 'Failed to fetch transaction '.$self->stash('transaction_number').': '.$error_code.' '.$error_message;
+                my $message = 'Failed to fetch transaction ' . $self->stash('transaction_number') . ': ' . $error_code . ' ' . $error_message;
                 error "%s", $message [API];
                 $self->render_exception($message);
         },
         error => sub {
             my ($api, $error) = @_;
-                my $message = 'Failed to fetch transaction '.$self->stash('transaction_number').': '.$error;
-                error "%s", $message [ROUTING];
-                $self->render_exception($message);
-        }
-   )->execute;
-   $self->render_later;
-};
-
-#-------------------------------------------------------------------------------
-
-sub _build_resume_link {
-    my ($self, $transaction, $resource )= @_;
-    
-    my $company_number = $transaction->{company_number};
-    my $transaction_id = $transaction->{id};
-    my $kind = $resource->{kind};
-    my $abridged_accounts_id;
-    my $resume_link;
-
-    my $resource_delay = Mojo::IOLoop::Delay->new;
-    my $resource_delay_end;
-    
-    if ( $kind eq "accounts") {
-        $resource_delay_end = $resource_delay->begin(0);
-        $self->_get_accounts_document($resource->{links}->{resource}, $resource_delay_end);
-    }
-
-    $resource_delay->on(
-        finish => sub {
-            my ($delay, $resource_link, $accounts_id) = @_;
             
-            if ( $resource_link && $kind eq "accounts" ){
-                if ( $resource_link =~/abridged\/(.*)$/ ) {
-                    $abridged_accounts_id = $1;
-                }
-                $resume_link = "/company/" . $company_number . "/transaction/" . $transaction_id . "/submit-abridged-accounts/" . $accounts_id ."/" . $abridged_accounts_id . "/accounting-reference-date";
-            }
-        
-            $self->redirect_to($resume_link);
-        },
-        error => sub {
-            my ($delay, $err) = @_;
-        
-            my $message = "Error getting accounts links : %s" . $err;
-            error "Error getting accounts links : %s". $err;
+            my $message = 'Error when fetching transaction ' . $self->stash('transaction_number') . ': ' . $error;
+            error "%s", $message [ROUTING];
             $self->render_exception($message);
         }
-    );
-
-}
-
-
-# ------------------------------------------------------------------------------
-
-sub _get_accounts_document {
-    my ($self, $resource_link, $callback) = @_;
-    
-    $self->ch_api->uri($resource_link)->get->on(
-             success => sub {
-                 my ($api, $tx) = @_;
-
-                 my $accounts = $tx->success->json;
-
-                 if ( defined $accounts->{links}->{abridged_accounts} ){
-                     $callback->($accounts->{links}->{abridged_accounts}, $accounts->{id});
-                 }
-                 return $callback->();
-             },
-             failure => sub {
-                 my ($api, $tx) = @_;
-
-                 my $error_code = $tx->error->{code} // 0;
-                 my $error_message = $tx->error->{message};
-
-                 if (defined $error_code and $error_code == 404) {
-                    error " Resource [%s] not found", $resource_link;
-                    $self->render_not_found;
-                 }
-                 my $message = "Error getting accounts links : %s". $resource_link;
-                 error "Error getting accounts links : %s", $resource_link [ RESUME LINK ];
-                 $self->render_exception($message);
-             },
-             error => sub {
-                 my ($api, $error) = @_;
-
-                 my $message = "Error getting accounts links : %s". $resource_link;
-                 error "Error getting accounts links : %s", $resource_link [ RESUME LINK ];
-                 $self->render_exception($message);
-             }
-         )->execute;
+   )->execute;
 }
 
 # ------------------------------------------------------------------------------

--- a/lib/ChGovUk/Controllers/User/Transactions/Resume.pm
+++ b/lib/ChGovUk/Controllers/User/Transactions/Resume.pm
@@ -27,11 +27,16 @@ sub resume {
             my $resume_link = $transaction->{links}->{resume};
             
             if (encode_base64url(sha1($resume_link)) ne $encoded_id) {
-                error "The transaction resume link does not match the encoded id";
-                $self->render_not_found;
+                my $message = "The transaction resume link does not match the encoded id";
+                error "%s", $message;
+                $self->render_exception($message);
             }
             
-            # TODO Check domain matches expected value and render error on failure
+            if ($resume_link !~ /^$config->{base}->{url}/) {
+                my $message = "The transaction resume link does not begin with the expected protocol or domain: ";
+                error "%s", $message;
+                $self->render_exception($message);
+            }
             
             $self->redirect_to($resume_link);
         },

--- a/lib/ChGovUk/Controllers/User/Transactions/Resume.pm
+++ b/lib/ChGovUk/Controllers/User/Transactions/Resume.pm
@@ -24,7 +24,7 @@ sub resume {
             
             my $transaction = $tx->success->json;
             
-            my $resume_link = $transaction->{links}->{resume};
+            my $resume_link = $transaction->{resume_journey_uri};
             
             if (encode_base64url($resume_link) ne $encoded_resume_link) {
                 my $message = "The transaction resume link does not match the encoded link url";

--- a/lib/ChGovUk/Controllers/User/Transactions/Resume.pm
+++ b/lib/ChGovUk/Controllers/User/Transactions/Resume.pm
@@ -7,7 +7,6 @@ use CH::Util::Pager;
 use CH::Util::DateHelper;
 use POSIX qw(strftime);
 use Mojo::IOLoop::Delay;
-use Digest::SHA qw(sha1);
 use MIME::Base64 qw(encode_base64url);
 
 #-------------------------------------------------------------------------------
@@ -27,7 +26,7 @@ sub resume {
             
             my $resume_link = $transaction->{links}->{resume};
             
-            if (encode_base64url(sha1($resume_link)) ne $encoded_id) {
+            if (encode_base64url($resume_link) ne $encoded_id) {
                 my $message = "The transaction resume link does not match the encoded id";
                 error "%s", $message;
                 $self->render_exception($message);

--- a/lib/ChGovUk/Controllers/User/Transactions/Resume.pm
+++ b/lib/ChGovUk/Controllers/User/Transactions/Resume.pm
@@ -16,7 +16,7 @@ sub resume {
     
     $self->render_later;
     
-    my $encoded_id = $self->param('id');
+    my $encoded_resume_link = $self->param('link');
     
     $self->ch_api->transactions($self->stash('transaction_number'))->get->on(
         success => sub {
@@ -26,19 +26,17 @@ sub resume {
             
             my $resume_link = $transaction->{links}->{resume};
             
-            if (encode_base64url($resume_link) ne $encoded_id) {
-                my $message = "The transaction resume link does not match the encoded id";
+            if (encode_base64url($resume_link) ne $encoded_resume_link) {
+                my $message = "The transaction resume link does not match the encoded link url";
                 error "%s", $message;
                 $self->render_exception($message);
             }
             
-            my $base_url = quotemeta($self->config->{base}->{url});
-            
-            if ($resume_link !~ /^$base_url.*/) {
-                my $message = "The transaction resume link does not begin with the expected protocol or domain: " . $resume_link;
-                error "%s", $message;
-                $self->render_exception($message);
-            }
+            # TODO: When support is added for third party (i.e. external) resume links, a check will need
+            # to be performed here to verify that the resume link matches a trusted domain for a given
+            # software vendor. A mechanism will be needed for adding the vendor to the transaction resource
+            # at creation time, and for registering one or more trusted domains that should be checked here.
+            # All Companies House resume links should be relative (i.e. not include the protocol or domain).
             
             $self->redirect_to($resume_link);
         },

--- a/lib/ChGovUk/Controllers/User/Transactions/Resume.pm
+++ b/lib/ChGovUk/Controllers/User/Transactions/Resume.pm
@@ -11,6 +11,7 @@ use Digest::SHA qw(sha1);
 use MIME::Base64 qw(encode_base64url);
 
 #-------------------------------------------------------------------------------
+
 sub resume {
     my ($self) = @_;
     
@@ -32,8 +33,10 @@ sub resume {
                 $self->render_exception($message);
             }
             
-            if ($resume_link !~ /^$config->{base}->{url}/) {
-                my $message = "The transaction resume link does not begin with the expected protocol or domain: ";
+            my $base_url = quotemeta($self->config->{base}->{url});
+            
+            if ($resume_link !~ /^$base_url.*/) {
+                my $message = "The transaction resume link does not begin with the expected protocol or domain: " . $resume_link;
                 error "%s", $message;
                 $self->render_exception($message);
             }

--- a/lib/ChGovUk/Controllers/User/Transactions/Resume.pm
+++ b/lib/ChGovUk/Controllers/User/Transactions/Resume.pm
@@ -31,7 +31,7 @@ sub resume {
                 $self->render_not_found;
             }
             
-            # TODO Render redirect confirmation for external links
+            # TODO Check domain matches expected value and render error on failure
             
             $self->redirect_to($resume_link);
         },

--- a/templates/includes/transactions.tx
+++ b/templates/includes/transactions.tx
@@ -49,7 +49,7 @@
                 % if $transaction.status == "open" {
                     <div class="column-third column-status" id="status-<% $~transaction.count %>">
                         Status<strong> Incomplete </strong>
-                        % if $transaction.resume_link && !$c.can_do('/admin/transaction-lookup'){
+                        % if $transaction.resume_link && !$c.can_do('/admin/transaction-lookup') {
                             <a class="piwik-event" data-event-id="resume" id="transaction-<% $~transaction.count %>-resume-link" href="<% $transaction.resume_link %>">Resume</a>
                         % }
                     </div>


### PR DESCRIPTION
These changes remove the coupling between the 'save and resume' functionality and abridged accounts and replaces this with a generic mechanism for retrieving the resume link from the transaction resource.

**Related pull-requests:**
* https://github.com/companieshouse/abridged.accounts.web.ch.gov.uk/pull/554
* https://github.com/companieshouse/company-accounts.web.ch.gov.uk/pull/119
* https://github.com/companieshouse/transactions.api.ch.gov.uk/pull/89

These changes also include a fix for failing builds due to dependency resolution issues—the `Test::Exception` module has been added as an explicit test dependency.

Resolves: SFA-42

