### PR TITLE
Bump dependency package version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PERL_DEPS_SERVER_URL ?= s3://release.ch.gov.uk/ch.gov.uk/deps
+PERL_DEPS_SERVER_URL ?= s3://release.ch.gov.uk/ch.gov.uk-deps
 PERL_DEPS_VERSION    ?= 1.0.0
 PERL_DEPS_PACKAGE    ?= ch.gov.uk-deps-$(PERL_DEPS_VERSION).zip
 PERL_DEPS_URL        ?= $(PERL_DEPS_SERVER_URL)/$(PERL_DEPS_PACKAGE)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PERL_DEPS_SERVER_URL ?= s3://release.ch.gov.uk/ch.gov.uk/deps
-PERL_DEPS_VERSION    ?= 1
+PERL_DEPS_VERSION    ?= 1.0.0
 PERL_DEPS_PACKAGE    ?= ch.gov.uk-deps-$(PERL_DEPS_VERSION).zip
 PERL_DEPS_URL        ?= $(PERL_DEPS_SERVER_URL)/$(PERL_DEPS_PACKAGE)
 


### PR DESCRIPTION
This changes brings the dependency package version in line with the first artefact built from the pipeline deployed to Concourse CI: https://ci.platform.aws.chdev.org/teams/development/pipelines/ch.gov.uk-deps/jobs/release/builds/1.