### PR TITLE
Accessibility fix: Remove duplicate form labels on CHS

### DIFF
--- a/templates/search/banner.tx
+++ b/templates/search/banner.tx
@@ -9,7 +9,6 @@
     <label class="hidden" for="site-search-text">Search for companies</label>
     <form id="search" action="/search/companies" method="get" accept-charset="utf-8" role="search" class="<% $header_or_body=='header' ? 'search-header' : 'search-header js-search-hash' %>">
 % } else {
-    <label class="hidden" for="site-search-text">Search for companies or officers</label>
     <form id="search" action="/search" method="get" accept-charset="utf-8" role="search" class="<% $header_or_body=='header' ? 'search-header' : 'search-header js-search-hash' %>">
 % }
     <div class="search-bar-active">


### PR DESCRIPTION
The search bar which appears at the top of "company" pages contains duplicate form labels. A form control should have at most one associated label element. If more than one label element is associated to the control, assistive technology may not read the appropriate label.

**Resolves**: PCI-158