### PR TITLE
Update content ids so that the skip link works while not affecting page style

### DIFF
--- a/templates/company/company_name_availability/form.html.tx
+++ b/templates/company/company_name_availability/form.html.tx
@@ -1,8 +1,8 @@
 % cascade base { title=> "Company Name Availability Checker - Companies House", classes=>"profile", disable_header_search => 1 }
 % around content -> {
 
-        <div class="column-full-width">
-                <h1 class="main-title left" id="content"">
+        <div class="column-full-width" id="content">
+                <h1 class="main-title left">
                     <label for="site-search-text" class="heading-xlarge">
                         Company name availability checker
                     </label>

--- a/templates/company/follow/list.html.tx
+++ b/templates/company/follow/list.html.tx
@@ -1,6 +1,7 @@
 % cascade base { title => 'Follow ' ~ $company.company_name , form_page => 1, classes => "transaction service" }
 % around content -> {
-	<div role="article" class="text follow-confirmation" id="content">
+  <div role="article" class="text follow-confirmation">
+        <div id="content" class="content-override"></div>
         <h1 class="heading-xlarge" id="follow-company-title"><% l('Follow a company') %></h1>
         <div class="text" id="follow-company-confirmation-prompt">
             <h2 class="heading-large"><% $company.company_name %> (<% $company.company_number %>)</h2>

--- a/templates/includes/company/page_header.tx
+++ b/templates/includes/company/page_header.tx
@@ -1,5 +1,6 @@
 <div class="company-header">
-        <p id="content" class="heading-xlarge"><% $company.company_name %></p>
+        <div id="content" class="content-override"></div>
+        <p class="heading-xlarge"><% $company.company_name %></p>
         <p id="company-number">
         % if $company.type == 'uk-establishment' {
         <% l('UK establishment number') %>

--- a/templates/includes/transactions.tx
+++ b/templates/includes/transactions.tx
@@ -1,6 +1,7 @@
 <a class="link-back id="back-button" href="javascript:history.back()">Back</a>
 
-<header class="text" id="content">
+<header class="text">
+    <div id="content" class="content-override"></div>
     <h1 id="page-header"class="heading-xlarge">
         <% $title %>
     </h1>

--- a/templates/personal_appointments/get.html.tx
+++ b/templates/personal_appointments/get.html.tx
@@ -4,7 +4,8 @@
 <script src='//<% $cdn_url %>/javascripts/vendor/selection-buttons.js'></script> <!-- Needed for new GDS-style radio buttons and checkboxes -->
 <script src='//<% $cdn_url %>/javascripts/vendor/application.js'></script>  <!-- Needed for new GDS-style radio buttons and checkboxes -->
 
-    <header class="text" id="content">
+    <div id="content" class="content-override"></div>
+    <header class="text">
         <h1 class="heading-xlarge" id="officer-name"><% $officer.name %></h1>
     </header>
 

--- a/templates/search/form.tx
+++ b/templates/search/form.tx
@@ -1,18 +1,18 @@
 % if $search_type == "officers" {
-    <form id="search" action="/search/officers" method="get" accept-charset="utf-8" role="search"  class="<% $header_or_body=='header'? 'site-search' : 'search-header js-search-hash' %>">
+    <form id="content" action="/search/officers" method="get" accept-charset="utf-8" role="search"  class="<% $header_or_body=='header'? 'site-search' : 'search-header js-search-hash' %>">
 % } elsif $search_type == 'disqualified-officers' {
-    <form id="search" action="/search/disqualified-officers" method="get" accept-charset="utf-8" role="search" class="<% $header_or_body=='header'? 'site-search' : 'search-header js-search-hash' %>">
+    <form id="content" action="/search/disqualified-officers" method="get" accept-charset="utf-8" role="search" class="<% $header_or_body=='header'? 'site-search' : 'search-header js-search-hash' %>">
 % } elsif $search_type == 'all' {
-    <form id="search" action="/search" method="get" accept-charset="utf-8" role="search" class="<% $header_or_body=='header' ? 'search-header' : 'search-header js-search-hash' %>">
+    <form id="content" action="/search" method="get" accept-charset="utf-8" role="search" class="<% $header_or_body=='header' ? 'search-header' : 'search-header js-search-hash' %>">
 % } else {
-    <form id="search" action="/search/companies" method="get" accept-charset="utf-8" role="search" class="<% $header_or_body=='header'? 'site-search' : 'search-header js-search-hash' %>">
+    <form id="content" action="/search/companies" method="get" accept-charset="utf-8" role="search" class="<% $header_or_body=='header'? 'site-search' : 'search-header js-search-hash' %>">
 % }
 
 % if ($header_or_body == 'header') {
 	<div class="content">
 % } else {
 % if !$results {
-    <h1 id="content" class="main-title center">
+    <h1 id="start-searching" class="main-title center">
                 <label class="heading-xlarge">
                   Search the register
                 </label>

--- a/templates/static_pages/help/contact-us.html.tx
+++ b/templates/static_pages/help/contact-us.html.tx
@@ -1,7 +1,8 @@
 % cascade base { title => 'Contact Us - Companies House service', searchpage => 1, disable_header_search => 1 }
 % around content -> {
     <article class="text">
-		<h1 id="content" class="heading-xlarge">Contact us</h1>
+    <div id="content" class="content-override"></div>
+		<h1 class="heading-xlarge">Contact us</h1>
         <p>You may find the answer to your enquiry on the <a href="https://www.gov.uk/government/organisations/companies-house">Companies House website</a> or you can <a href="mailto:enquiries@companieshouse.gov.uk">email us</a>.</p>
         <h2 class="heading-medium">Contact Centre</h2>
             <ul class="text-list">

--- a/templates/static_pages/help/cookies.html.tx
+++ b/templates/static_pages/help/cookies.html.tx
@@ -3,7 +3,7 @@
 
    <article class="text" id="content">
 
-      <h1 id="content" class="heading-xlarge">
+      <h1 class="heading-xlarge">
         Cookies
       </h1>
       <p>Companieshouse.gov.uk puts small files (known as ‘cookies’) onto your computer to collect information about how you browse the site.</p>

--- a/templates/static_pages/help/guidance.html.tx
+++ b/templates/static_pages/help/guidance.html.tx
@@ -7,7 +7,8 @@
 
 <div class="text">
     <header>
-        <h1 class="heading-xlarge" id="content">File abridged or full accounts</h1>
+        <div id="content" class="content-override"></div>
+        <h1 class="heading-xlarge">File abridged or full accounts</h1>
     </header>
 
     <p>You can now file abridged or full accounts here too. While we develop this new service, you should continue to use <a href="https://www.gov.uk/government/organisations/companies-house/about/about-our-services#webfiling">WebFiling<span class="visuallyhidden"> Link opens in new tab/window</span></a> for other types of accounts.</p>

--- a/templates/static_pages/help/other-filings.html.tx
+++ b/templates/static_pages/help/other-filings.html.tx
@@ -7,7 +7,8 @@
 
 <div class="text">
     <header>
-        <h1 class="heading-xlarge" id="content">Other document filings</h1>
+        <div id="content" class="content-override"></div>
+        <h1 class="heading-xlarge">Other document filings</h1>
     </header>
 
     <p>During the beta service development you should continue to use <a href="https://www.gov.uk/government/organisations/companies-house/about/about-our-services#webfiling">WebFiling<span class="visuallyhidden"> Link opens in new tab/window</span></a> to file your company information online.</p>


### PR DESCRIPTION
Content id required for skip link to work - however the id contains styling which throws off the pages style. An override class has been added to prevent this.

**Resolves**:  PCI-186