### PR TITLE
PCI-198: Loosen up condition for success to cover all 2xx responses

### DIFF
--- a/lib/ChGovUk/Controllers/Company/Document.pm
+++ b/lib/ChGovUk/Controllers/Company/Document.pm
@@ -170,10 +170,12 @@ sub publish_response {
     my ($self, $response) = @_;
     my $responseCode = $response->responseCode();
     my $responseContent = $response->responseContent();
+    my $isSuccess = $responseCode >= 200 && $responseCode < 300;
     trace "Response code for request to SCUD API = %s", $responseCode;
     trace "Response content = %s", $responseContent;
     $self->stash(response_code => $responseCode);
     $self->stash(response_content => $responseContent);
+    $self->stash(is_success => $isSuccess);
 }
 
 #-------------------------------------------------------------------------------

--- a/templates/company/document/scud.html.ep
+++ b/templates/company/document/scud.html.ep
@@ -1,5 +1,5 @@
 <div>
-  % if ($response_code == 201) {
+  % if ($is_success) {
     <h1>Document ordered</h1>
     <h2>Please return to the filing history for the document <%= $filing_history_id %> in 24 hours.</h2>
   % } else {


### PR DESCRIPTION
* Changes made to SCUD API result in it returning 200 OK rather than 201 Created.
* Distinction not seen as being important and hence this client side validation has been loosened.