### PR TITLE
Accessibility - Remove autofocus from CHS form controls

### DIFF
--- a/templates/company/company_name_availability/form.html.tx
+++ b/templates/company/company_name_availability/form.html.tx
@@ -13,7 +13,7 @@
             <form id="name-availability-search" action="/company-name-availability" method="get" accept-charset="utf-8" role="name-availability-search" class="search-header js-search-hash">
 
                 <div class="searchfield">
-                    <input type="search" autocomplete="off" name="q" id="company-name-availability-search-text" title="Search" value="<% $query %>" placeholder="Search" autofocus="autofocus" class="js-search-focus" />
+                    <input type="search" autocomplete="off" name="q" id="company-name-availability-search-text" title="Search" value="<% $query %>" placeholder="Search"/>
                     <button type="submit" id="search-submit" class="search-submit">Search</button>
                     <p id="slowsearch" class="slow-search-msg" style="display:none">Please press ENTER to search</p>
                 </div>

--- a/templates/search/banner.tx
+++ b/templates/search/banner.tx
@@ -14,7 +14,7 @@
     <div class="search-bar-active">
         <div class="searchfield">
             <label class="hidden" for="site-search-text">Search for a company or officer</label>
-            <input type="search" class="js-search-focus" autofocus="autofocus" placeholder="Search for a company or officer" value="" title="Search for a company or officer" id="site-search-text" name="q" autocomplete="off">
+            <input type="search" placeholder="Search for a company or officer" value="" title="Search for a company or officer" id="site-search-text" name="q" autocomplete="off">
             <button class="search-submit" id="search-submit" type="submit">Search</button>
             <p style="display:none" class="slow-search-msg" id="slowsearch">Please press ENTER to search</p>
         </div>  <!--end searchfield-->

--- a/templates/search/form.tx
+++ b/templates/search/form.tx
@@ -23,7 +23,7 @@
 	    <div class="searchfield">
 % }
         <label class="visuallyhidden" for="site-search-text">Enter company name, number or officer name</label>
-		    <input type="search" autocomplete="off" name="q" id="site-search-text" title="Search" value="<% $results.searchTerm %>" <% if ($header_or_body == 'header') { %> placeholder="Search"  class="header-search"<% } else { %> placeholder="Start here..." autofocus="autofocus" class="js-search-focus"<% } %> />
+		    <input type="search" autocomplete="off" name="q" id="site-search-text" title="Search" value="<% $results.searchTerm %>" <% if ($header_or_body == 'header') { %> placeholder="Search"  class="header-search"<% } else { %> placeholder="Start here..."<% } %> />
 % if ($header_or_body == 'header') {
         <input class="submit" type="submit" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackEvent', 'SiteSearch', 'Header']);"<% } %> id="search-btn" value="Search" />
 % } else {


### PR DESCRIPTION
Automatically focusing a form control can confuse visually-impaired people using screen-reading technology. Therefore it should be removed from the search forms present in CHS.

**Resolves**: PCI-183