### PR TITLE
Post etag when submitting a change of ROA

### DIFF
--- a/lib/ChGovUk/Controllers/Company/Transactions/ChangeRegisteredOfficeAddress.pm
+++ b/lib/ChGovUk/Controllers/Company/Transactions/ChangeRegisteredOfficeAddress.pm
@@ -42,7 +42,7 @@ sub get {
         success => sub {
             my ($api, $tx) = @_;
             my $addr = ChGovUk::Models::Address->new->from_api_hash($tx->success->json);
-            $self->stash(old_address => $addr->as_string, po_box => $addr->po_box, care_of => $addr->care_of, disable_header_search => 1);
+            $self->stash(old_address => $addr->as_string, po_box => $addr->po_box, care_of => $addr->care_of, disable_header_search => 1, etag => $addr->etag);
             $self->render(template => 'company/transactions/change_registered_office_address');
         }
     )->execute;

--- a/lib/ChGovUk/Models/Address.pm
+++ b/lib/ChGovUk/Models/Address.pm
@@ -65,7 +65,7 @@ sub as_api_hash {
 
     my $api_hash = {};
 
-    $api_hash->{etag}           = $self->etag     if $self->etag;
+    $api_hash->{reference_etag} = $self->etag     if $self->etag;
     $api_hash->{premises}       = $self->premises if $self->premises;
     $api_hash->{address_line_1} = $self->line_1   if $self->line_1;
     $api_hash->{address_line_2} = $self->line_2   if $self->line_2;

--- a/lib/ChGovUk/Models/Address.pm
+++ b/lib/ChGovUk/Models/Address.pm
@@ -35,6 +35,7 @@ my $country_codes = {
 
 #-------------------------------------------------------------------------------
 
+has 'etag'          => ( traits => ['Populate'],            is => 'rw' );
 has 'premises'      => ( traits => ['Populate','Validate'], is => 'rw' );
 has 'line_1'        => ( traits => ['Populate','Validate'], is => 'rw' );
 has 'line_2'        => ( traits => ['Populate','Validate'], is => 'rw' );
@@ -64,6 +65,7 @@ sub as_api_hash {
 
     my $api_hash = {};
 
+    $api_hash->{etag}           = $self->etag     if $self->etag;
     $api_hash->{premises}       = $self->premises if $self->premises;
     $api_hash->{address_line_1} = $self->line_1   if $self->line_1;
     $api_hash->{address_line_2} = $self->line_2   if $self->line_2;
@@ -83,6 +85,7 @@ sub from_api_hash {
     my ($self, $api_hash) = @_;
 
     $api_hash->{$_} ||= '' for qw(
+        etag
         premises
         address_line_1
         address_line_2
@@ -94,6 +97,7 @@ sub from_api_hash {
         care_of
     );
 
+    $self->etag    ( $api_hash->{etag} );
     $self->premises( $api_hash->{premises} );
     $self->line_1  ( $api_hash->{address_line_1} );
     $self->line_2  ( $api_hash->{address_line_2} );

--- a/t/unit/ChGovUk/Models/Address.t
+++ b/t/unit/ChGovUk/Models/Address.t
@@ -41,6 +41,7 @@ done_testing();
 sub test_method_from_api_hash {
     subtest "Test method - from_api_hash" => sub {
         my $api_hash = {
+            etag             => 'cbff69a7a36ffd48acc4196b242d055ead5e2853',
             premises         => 'Civic Centre',
             address_line_1   => 'Oystermouth Road',
             address_line_2   => 'The Seafront',
@@ -60,6 +61,7 @@ sub test_method_from_api_hash {
 
         $address->from_api_hash( $api_hash );
 
+        is( $address->etag    , $api_hash->{etag}, 'cbff69a7a36ffd48acc4196b242d055ead5e2853' );
         is( $address->premises, $api_hash->{premises}, 'Premises' );
         is( $address->line_1  , $api_hash->{address_line_1}, 'Line 1' );
         is( $address->line_2  , $api_hash->{address_line_2}, 'Line 2' );
@@ -95,6 +97,7 @@ sub test_method_as_api_hash {
         };
 
         subtest "Populated" => sub {
+            $address->etag      ( 'cbff69a7a36ffd48acc4196b242d055ead5e2853'  );
             $address->premises  ( '21 The Cottage'  );
             $address->line_1    ( 'Fake Street'     );
             $address->line_2    ( 'The cul-de-sac'  );
@@ -108,7 +111,8 @@ sub test_method_as_api_hash {
             my $result = $address->as_api_hash;
             is_deeply(
                 $result,
-                {   premises         => '21 The Cottage',
+                {   reference_etag   => 'cbff69a7a36ffd48acc4196b242d055ead5e2853',
+                    premises         => '21 The Cottage',
                     address_line_1   => 'Fake Street',
                     address_line_2   => 'The cul-de-sac',
                     locality         => 'Cardiff',

--- a/templates/company/transactions/change_registered_office_address.html.tx
+++ b/templates/company/transactions/change_registered_office_address.html.tx
@@ -8,7 +8,6 @@
     <legend class="heading-medium text">What is the new address of the company?</legend>
     % $c.include_later('includes/forms/errors', form => $form, form_title => 'Filing Error');
     % include 'includes/forms/address.tx' { form => $form, name => 'address', include_po_box => 1 }
-    % $form.hidden_field( name => 'reference_etag', value => $etag );
+    % $form.hidden_field( name => 'address[etag]', value => $etag );
 </fieldset>
 % }
-

--- a/templates/company/transactions/change_registered_office_address.html.tx
+++ b/templates/company/transactions/change_registered_office_address.html.tx
@@ -8,6 +8,7 @@
     <legend class="heading-medium text">What is the new address of the company?</legend>
     % $c.include_later('includes/forms/errors', form => $form, form_title => 'Filing Error');
     % include 'includes/forms/address.tx' { form => $form, name => 'address', include_po_box => 1 }
+    % $form.hidden_field( name => 'reference_etag', value => $etag );
 </fieldset>
 % }
 


### PR DESCRIPTION
Add a hidden field `reference_etag` to be sent when changing a registered office address. This is populated with the `etag` value returned by the ROA API

Resolves FA-271