### PR TITLE
Display etag mismatch error

### DIFF
--- a/errors.yml
+++ b/errors.yml
@@ -124,6 +124,11 @@ errors:
               minlength: "Secretary of State authorisation code has an invalid value - it must be 4 characters long"
               maxlength: "Secretary of State authorisation code has an invalid value - it must be 4 characters long"
 
+          change_registered_office_address:
+            address:
+              etag:
+                etag-mismatch: "This address has been recently updated. Check the current address to see if it's correct."
+
           register_charge:
             creation_date:
               before_incorporation_date: "The Date of Creation must be on or after the date of incorporation"

--- a/lib/ChGovUk/Models/Company/Transactions/ChangeRegisteredOfficeAddress.pm
+++ b/lib/ChGovUk/Models/Company/Transactions/ChangeRegisteredOfficeAddress.pm
@@ -14,6 +14,7 @@ our %api_field_map = (
     'address[postcode]' => 'postal_code',
     'address[country]'  => 'country',
     'address[po_box]'   => 'po_box',
+    'address[etag]'     => 'reference_etag',
 );
 
 #-------------------------------------------------------------------------------

--- a/templates/company/transactions/change_registered_office_address.html.tx
+++ b/templates/company/transactions/change_registered_office_address.html.tx
@@ -8,6 +8,5 @@
     <legend class="heading-medium text">What is the new address of the company?</legend>
     % $c.include_later('includes/forms/errors', form => $form, form_title => 'Filing Error');
     % include 'includes/forms/address.tx' { form => $form, name => 'address', include_po_box => 1 }
-    % $form.hidden_field( name => 'address[etag]', value => $etag );
 </fieldset>
 % }

--- a/templates/company/transactions/current_address.html.tx
+++ b/templates/company/transactions/current_address.html.tx
@@ -1,4 +1,5 @@
 <p class="text">
+    % $form.hidden_field( name => 'address[etag]', value => $etag );
 	Current address
 	<br />
     % if $care_of_name {


### PR DESCRIPTION
Display error when the address reference etag does not match the company profile etag
Move the hidden field next to the current address so that the error link takes you to the current address for review

Part of FA-396 and FA-397

Note this needs to be made a warning, not an error. Changes to handle warnings will be done later