### PR TITLE
Display warnings

### DIFF
--- a/lib/ChGovUk/Plugins/FormHelpers.pm
+++ b/lib/ChGovUk/Plugins/FormHelpers.pm
@@ -502,7 +502,7 @@ sub _get_errors_for_field {
             $error_hash{text} = $error;
 
             if ($self->_is_warning($rule)) {
-                push $self->warnings, \%error_hash;
+                push @{$self->warnings}, \%error_hash;
             } else {
                 my $error_id = $self->_field_name_to_id($field) . '-' . $rule . '-error';
                 push @errors, { text => $error, id => $error_id };
@@ -510,7 +510,7 @@ sub _get_errors_for_field {
                 # Does the controller have a corresponding field?
                 if (defined $self->labels->{$field} ) {
                     $error_hash{id}   = $error_id;
-                    push $self->errors, \%error_hash;
+                    push @{$self->errors}, \%error_hash;
                 }
             }
         }

--- a/lib/ChGovUk/Plugins/FormHelpers.pm
+++ b/lib/ChGovUk/Plugins/FormHelpers.pm
@@ -12,6 +12,7 @@ has 'controller';
 has 'model';
 has 'labels'         => sub { {} };
 has 'errors'         => sub { [] };
+has 'warnings'       => sub { [] };
 has 'blocks'         => sub { [] };
 
 # ========================================================| MOJO INTERFACE |====
@@ -40,6 +41,16 @@ sub errors_count {
 
     my $count = scalar @{ $self->errors };
     trace "There are %s errors", $count [VALIDATION];
+    return $count;
+}
+
+# -----------------------------------------------------------------------------
+
+sub warnings_count {
+    my ($self) = @_;
+
+    my $count = scalar @{ $self->warnings };
+    trace "There are %s warnings", $count [VALIDATION];
     return $count;
 }
 
@@ -484,18 +495,23 @@ sub _get_errors_for_field {
             }
 
             $error = Locale::Simple::l($error, { %error_args } );
-            my $error_id = $self->_field_name_to_id($field) . '-' . $rule . '-error';
-            push @errors, { text => $error, id => $error_id };
 
             # Add error to global error array
             my %error_hash;
             $error_hash{name} = $field;
             $error_hash{text} = $error;
 
-            # Does the controller have a corresponding field?
-            if ( defined $self->labels->{$field} ) {
-                $error_hash{id}   = $error_id;
-                push $self->errors, \%error_hash;
+            if ($self->_is_warning($rule)) {
+                push $self->warnings, \%error_hash;
+            } else {
+                my $error_id = $self->_field_name_to_id($field) . '-' . $rule . '-error';
+                push @errors, { text => $error, id => $error_id };
+
+                # Does the controller have a corresponding field?
+                if (defined $self->labels->{$field} ) {
+                    $error_hash{id}   = $error_id;
+                    push $self->errors, \%error_hash;
+                }
             }
         }
     }
@@ -652,6 +668,13 @@ sub _field_name_parts {
 sub _field_name_to_id  {
     my ($self, $field) = @_;
     return join( '-', $self->_field_name_parts($field) ) // undef;
+}
+
+# -----------------------------------------------------------------------------
+
+sub _is_warning  {
+    my ($self, $rule) = @_;
+    return $rule eq "etag-mismatch";
 }
 
 # -----------------------------------------------------------------------------

--- a/templates/company/transactions/change_registered_office_address.html.tx
+++ b/templates/company/transactions/change_registered_office_address.html.tx
@@ -8,5 +8,6 @@
     <legend class="heading-medium text">What is the new address of the company?</legend>
     % $c.include_later('includes/forms/errors', form => $form, form_title => 'Filing Error');
     % include 'includes/forms/address.tx' { form => $form, name => 'address', include_po_box => 1 }
+    % $form.hidden_field( name => 'address[etag]', value => $etag );
 </fieldset>
 % }

--- a/templates/company/transactions/current_address.html.tx
+++ b/templates/company/transactions/current_address.html.tx
@@ -1,5 +1,4 @@
 <p class="text">
-    % $form.hidden_field( name => 'address[etag]', value => $etag );
 	Current address
 	<br />
     % if $care_of_name {

--- a/templates/includes/forms/errors.html.tx
+++ b/templates/includes/forms/errors.html.tx
@@ -1,15 +1,29 @@
-% if $form.model && $form.errors_count() > 0 {
-    <div class="error-summary" role="group" tabindex="-1">
-        <h2 class="heading-medium error-summary-heading">
-            <% $form_title %>
-        </h2>
-        <p>
-            This form has errors
-        </p>
-        <ul class="error-summary-list">
-        % for $form.errors -> $error {
-            <li><a href="#<% $error.id %>"><% $error.text %></a></li>
+% if $form.model {
+    % if $form.warnings_count() > 0 {
+        % for $form.warnings -> $warning {
+        <div class="govuk-warning-text">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text">
+                <span class="govuk-warning-text__assistive">Warning</span>
+                <% $warning.text %>
+            </strong>
+        </div>
         % }
-        </ul>
-    </div>
+    % }
+
+    % if $form.errors_count() > 0 {
+        <div class="error-summary" role="group" tabindex="-1">
+            <h2 class="heading-medium error-summary-heading">
+                <% $form_title %>
+            </h2>
+            <p>
+                This form has errors
+            </p>
+            <ul class="error-summary-list">
+            % for $form.errors -> $error {
+                <li><a href="#<% $error.id %>"><% $error.text %></a></li>
+            % }
+            </ul>
+        </div>
+    % }
 % }


### PR DESCRIPTION
Create and display form warnings, currently the only warning being `etag-mismatch`

Move the hidden field back next to the other address fields since it is no longer linked from the error section

Part of FA-396 and FA-397

See #109