### PR TITLE
FA-605 Generate POST request for ROA address change.

### DIFF
--- a/lib/ChGovUk/Models/Company/Transactions/ChangeRegisteredOfficeAddress.pm
+++ b/lib/ChGovUk/Models/Company/Transactions/ChangeRegisteredOfficeAddress.pm
@@ -31,10 +31,10 @@ sub get_api_map {
 
 sub update_api {
     my ( $self, $transaction, ) = @_;
-    return $transaction->registered_office_address->update( $self->address->as_api_hash );
+    return $transaction->registered_office_address->create( $self->address->as_api_hash );
 }
 
-# ------------------------------------------------------------------------------ 
+# ------------------------------------------------------------------------------
 
 __PACKAGE__->meta->make_immutable;
 


### PR DESCRIPTION
Generate a POST request for change of ROA. Currently a PUT request.

* ROA API throwing an error: `error: ROA resource doesn't exist for PUT request`
* Found that an `update()` call being made on transaction instead of `create()`; resulting in a `PUT` request instead of the required `POST` request.

Resolves:
FA-605 