### PR TITLE
Fix broken accessibility by removing aria-describedby

### DIFF
--- a/templates/company/view_all/view.html.tx
+++ b/templates/company/view_all/view.html.tx
@@ -4,12 +4,6 @@
   % if $show_snapshot {
     % include '/includes/company/page_header.tx'
 
-    % if $show_snapshot && $show_orders {
-      <p class="hidden" id="described-by">Get company snapshot and ordering service</p>
-    % } else {
-      <p class="hidden" id="described-by">Get company snapshot</p>
-    % }
-
     % include '/includes/company/tabs.tx' { active => 'more-tab' };
         <h2 id="company-snapshot-header" class="heading-large">
           Company snapshot <%$company_type%>

--- a/templates/includes/company/tab.tx
+++ b/templates/includes/company/tab.tx
@@ -4,12 +4,11 @@
  %#   $page    - the URL relative to /company/{company_number} that this tab links to
  %#   $title   - the title heading of the tab (may contain HTML)
  %#   $company - the company details needed for display (uses company.company_number)
- %#   $describedBy - the descriptive text read to a screen reader user
 
  <li <% ($active == $tabid ? 'class="active"' : '') | raw %> >
 
      % if ( $active == $tabid ) { "<h1>" | raw }
-         <a id="<% $tabid %>" aria-describedby="<% $describedBy %>" href="<% $c.url_for('/company/' ~ $company.company_number ~ $page) %>"><% $title|raw %><span class="visuallyhidden"> for <% $company.company_name %> (<% $company.company_number %>)</span></a>
+         <a id="<% $tabid %>" href="<% $c.url_for('/company/' ~ $company.company_number ~ $page) %>"><% $title|raw %><span class="visuallyhidden"> for <% $company.company_name %> (<% $company.company_number %>)</span></a>
      % if ( $active == $tabid ) { "</h1>" | raw }
 
  </li>

--- a/templates/includes/company/tabs.tx
+++ b/templates/includes/company/tabs.tx
@@ -23,7 +23,7 @@
 
         % if $c.config.feature.company_report {
           % if $company.type != "assurance-company" && $company.type != "industrial-and-provident-society" && $company.type != "royal-charter"  && $company.type != "investment-company-with-variable-capital" && $company.type != "charitable-incorporated-organisation" && $company.type != "scottish-charitable-incorporated-organisation" && $company.type != "uk-establishment" && $company.type != "registered-society-non-jurisdictional" && $company.type != "protected-cell-company" && $company.type != "eeig" && $company.type != "protected-cell-company" && $company.type != "further-education-or-sixth-form-college-corporation"  && $company.type != "icvc-securities" && $company.type != "icvc-warrant" && $company.type != "icvc-umbrella" {
-            %     include "/includes/company/tab.tx" { tabid => 'more-tab', page => '/more', title => 'More', describedBy => 'described-by'};
+            %     include "/includes/company/tab.tx" { tabid => 'more-tab', page => '/more', title => 'More'};
           % }
        % }
     </ul>


### PR DESCRIPTION
The `aria-describedby` was causing accessibility failures therefore recommended to remove until further investigation.
Resolves: GCI-1038