### PR TITLE
Certified documents alternate filing history screen

### DIFF
--- a/lib/ChGovUk/Controllers/Company/CertifiedDocuments.pm
+++ b/lib/ChGovUk/Controllers/Company/CertifiedDocuments.pm
@@ -13,9 +13,6 @@ use ChGovUk::Plugins::FilterHelper;
 use DateTime;
 
 # all categories (that can be filtered by)
-# XXX temp: need decision on what categories we're going to display and where the
-# canonical list should be (e.g. in here, hardwired in the template, in a YAML file,
-# pulled from MongoDB &c.)
 use constant AVAILABLE_CATEGORIES => {
     'accounts'               => 'Accounts',
     'confirmation-statement' => 'Confirmation statements / Annual returns',

--- a/lib/ChGovUk/Controllers/Company/CertifiedDocuments.pm
+++ b/lib/ChGovUk/Controllers/Company/CertifiedDocuments.pm
@@ -1,4 +1,4 @@
-package ChGovUk::Controllers::Company::FilingHistory;
+package ChGovUk::Controllers::Company::CertifiedDocuments;
 
 use Mojo::Base 'Mojolicious::Controller';
 use Mojo::IOLoop;
@@ -32,10 +32,10 @@ sub view {
     my ($self) = @_;
 
     # Process the incoming parameters
-    my $company_number   = $self->param('company_number');      # Mandatory
-    my $page             = abs(int($self->param('page') || 1)); # Which page has been requested
-    my $show_filing_type = $self->get_filter('fh_type');        # Show the filing-type column/containers
-    my $category_filter  = $self->get_filter('fh');             # List of categories to filter by (optional)
+    my $company_number   = $self->param('company_number');                # Mandatory
+    my $page             = abs(int($self->param('page') || 1));           # Which page has been requested
+    my $show_filing_type = $self->get_filter('fh_type');                  # Show the filing-type column/containers
+    my $category_filter  = $self->get_filter('fh');                       # List of categories to filter by (optional)
     my @filter_categories = split ',', $category_filter;
 
     my $unavailable_date = $self->config->{unavailable_date} || '2003-01-01';
@@ -43,11 +43,8 @@ sub view {
     my $recently_filed = $self->config->{recently_filed_days} || 5;
     my $items_per_page = $self->config->{filing_history}->{items_per_page} || 25;
 
-    # FIXME: vvv Remove this when Doc API goes live (and in template) vvv
     $self->stash->{image_service_active} = $self->can_view_images;
-    # FIXME: ^^^ Remove this when Doc API goes live (and in template) ^^^
 
-    # FIXME: remove this when confirmation-statement goes live - also in template
     my $confirmation_statement_available_date = $self->config->{confirmation_statement_available_date} || '2016-06-30';
 
     my $date_today = DateTime->now(time_zone => 'GMT');
@@ -55,7 +52,6 @@ sub view {
     if (date_convert($date_today) < date_convert($confirmation_statement_available_date)) {
         $self->stash(disable_confirmation_statement_filter => 1);
     }
-    # FIXME remove this when confirmation-statement goes live - also in template
 
     trace "Get company filing history for %s, page %s, filter=[%s]", $self->stash('company_number'), $page, $category_filter [FILING_HISTORY];
     my $pager = CH::Util::Pager->new(entries_per_page => $items_per_page, current_page => $page);
@@ -143,10 +139,10 @@ sub view {
             $self->stash(split_category_at       => ceil(@$categories / 2));
 
             if ($self->req->is_xhr) {
-                $self->render(template => 'company/filing_history/view_content');
+                $self->render(template => 'company/filing_history/view_content_certified');
             }
             else {
-                $self->render;
+                $self->render(template => 'company/filing_history/view_certified');
             }
         },
         failure => sub {
@@ -170,10 +166,6 @@ sub date_convert {
       );
 }
 
-#-------------------------------------------------------------------------------
-# FIXME THIS SHOULD ALL BE DONE INSIDE THE TEMPLATE             FIXME
-# FIXME IF WE CAN...........                                    FIXME
-# FIXME IF WE CANNOT - THEN WHAT ARE API USERS GOING TO DO????? FIXME
 sub _dates_to_strings {
     my ( $self, $description_values, ) = @_;
 
@@ -181,7 +173,5 @@ sub _dates_to_strings {
         $description_values->{$field} = CH::Util::DateHelper->isodate_as_string( $description_values->{$field}, "%d %b %Y" );
     }
 }
-
-#-------------------------------------------------------------------------------
 
 1;

--- a/lib/ChGovUk/Controllers/Company/CertifiedDocuments.pm
+++ b/lib/ChGovUk/Controllers/Company/CertifiedDocuments.pm
@@ -53,6 +53,13 @@ sub view {
         $self->stash(disable_confirmation_statement_filter => 1);
     }
 
+    if( ! $self->is_signed_in ) {
+        my $return_to = $self->req->headers->referrer . ',' . scalar $self->req->url;
+        debug "Certified Documents - user not logged in, redirecting to login with return_to[%s]", $return_to [ROUTING];
+        $self->redirect_to( $self->url_for('user_sign_in')->query( return_to => $return_to) );
+        return 0;
+    }
+
     trace "Get company filing history for %s, page %s, filter=[%s]", $self->stash('company_number'), $page, $category_filter [FILING_HISTORY];
     my $pager = CH::Util::Pager->new(entries_per_page => $items_per_page, current_page => $page);
 

--- a/lib/ChGovUk/Controllers/Company/CertifiedDocuments.pm
+++ b/lib/ChGovUk/Controllers/Company/CertifiedDocuments.pm
@@ -27,7 +27,7 @@ use constant AVAILABLE_CATEGORIES => {
 
 #-------------------------------------------------------------------------------
 
-# Company filing history page
+# Certified documents filing history page
 sub view {
     my ($self) = @_;
 

--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -32,11 +32,11 @@ sub view {
     my ($self) = @_;
 
     # Process the incoming parameters
-    my $company_number   = $self->param('company_number');          # Mandatory
-    my $cert             = abs(int($self->param('cert') || 0));
-    my $page             = abs(int($self->param('page') || 1));     # Which page has been requested
-    my $show_filing_type = $self->get_filter('fh_type');            # Show the filing-type column/containers
-    my $category_filter  = $self->get_filter('fh');                 # List of categories to filter by (optional)
+    my $company_number   = $self->param('company_number');                # Mandatory
+    my $certified_docs   = abs(int($self->param('certified_docs') || 0)); # Certified documents query parameter
+    my $page             = abs(int($self->param('page') || 1));           # Which page has been requested
+    my $show_filing_type = $self->get_filter('fh_type');                  # Show the filing-type column/containers
+    my $category_filter  = $self->get_filter('fh');                       # List of categories to filter by (optional)
     my @filter_categories = split ',', $category_filter;
 
     my $unavailable_date = $self->config->{unavailable_date} || '2003-01-01';
@@ -126,8 +126,6 @@ sub view {
                 $self->format_filing_history_dates($doc);
             }
 
-            trace "THIS IS THE FLAG VALUE FOR CERT: %s", $cert;
-
             # Work out the paging numbers
             $pager->total_entries( $fh_results->{total_count} // 0 );
             trace "filing history total_count %d entries per page %d",
@@ -149,7 +147,7 @@ sub view {
                 $self->render(template => 'company/filing_history/view_content');
             }
             else {
-                if ($cert) {
+                if ($certified_docs) {
                     $self->render(template => 'company/filing_history/view_certified');
                 } else {
                     $self->render;

--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -33,6 +33,7 @@ sub view {
 
     # Process the incoming parameters
     my $company_number   = $self->param('company_number');          # Mandatory
+    my $cert             = abs(int($self->param('cert') || 0));
     my $page             = abs(int($self->param('page') || 1));     # Which page has been requested
     my $show_filing_type = $self->get_filter('fh_type');            # Show the filing-type column/containers
     my $category_filter  = $self->get_filter('fh');                 # List of categories to filter by (optional)
@@ -124,6 +125,8 @@ sub view {
                 # Format date fields in the form of '01 Jan 2004'
                 $self->format_filing_history_dates($doc);
             }
+
+            trace "THIS IS THE FLAG VALUE FOR CERT: %s", $cert;
 
             # Work out the paging numbers
             $pager->total_entries( $fh_results->{total_count} // 0 );

--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -149,7 +149,11 @@ sub view {
                 $self->render(template => 'company/filing_history/view_content');
             }
             else {
-                $self->render;
+                if ($cert) {
+                    $self->render(template => 'company/filing_history/view_certified');
+                } else {
+                    $self->render;
+                }
             }
         },
         failure => sub {

--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -32,10 +32,10 @@ sub view {
     my ($self) = @_;
 
     # Process the incoming parameters
-    my $company_number   = $self->param('company_number');      # Mandatory
-    my $page             = abs(int($self->param('page') || 1)); # Which page has been requested
-    my $show_filing_type = $self->get_filter('fh_type');        # Show the filing-type column/containers
-    my $category_filter  = $self->get_filter('fh');             # List of categories to filter by (optional)
+    my $company_number   = $self->param('company_number');          # Mandatory
+    my $page             = abs(int($self->param('page') || 1));     # Which page has been requested
+    my $show_filing_type = $self->get_filter('fh_type');            # Show the filing-type column/containers
+    my $category_filter  = $self->get_filter('fh');                 # List of categories to filter by (optional)
     my @filter_categories = split ',', $category_filter;
 
     my $unavailable_date = $self->config->{unavailable_date} || '2003-01-01';

--- a/lib/ChGovUk/Plugins/Routes.pm
+++ b/lib/ChGovUk/Plugins/Routes.pm
@@ -60,6 +60,7 @@ sub register {
     my $company_bridge = $root->find('company');
     $company_bridge->get('/')->name('company_profile')->to('company#view');
     $company_bridge->get('/filing-history')->name('company_filing_history')->to('company-filing_history#view');
+    $company_bridge->get('/certified-documents')->name('company_certified_documents')->to('company-certified_documents#view');
     $company_bridge->get('/officers')->name('company_officers')->to('company-officers#list');
     $company_bridge->get('/registers')->name('company_registers')->to('company-registers#list');
     $company_bridge->get('/registers/directors')->name('company_registers_directors')->to('company-registers-directors#list');

--- a/templates/base.tx
+++ b/templates/base.tx
@@ -115,6 +115,8 @@
       </div>
    </div>
 
+% if ! $disable_default_header {
+
   <!-- // CH.GOV.UK HEADER -->
   <header role="banner" id="global-header">
     <div class="header-wrapper">
@@ -127,12 +129,17 @@
 			<!--<a href="#search" class="search-toggle js-header-toggle">Search</a>-->
 % }
         </div>
-
+        <div>
+            <a href="/" title="Go to the Companies House homepage"<% if $c.config.piwik.embed { %> onClick="javascript:_paq.push(['trackEvent', 'CHLogo', 'Homepage']);"<% } %> id="service-logo" class="content">
+            Order a certified copy
+          </a>
+          </div>
 
       </div>
     </div>
   </header>
   <!--end header-->
+% }
 
 % if $feedback_banner {
   <div class="govuk-body" id="chs-customer-insights-top">
@@ -145,11 +152,18 @@
   <main id="page-container" class="search <% $classes %>" role="main">
 
   % if !$feedback_banner {
-    <div class="phase-banner">
-      % } else {
+    % if $certified_copies {
+      <div class="phase-banner-certified">
+    % } else {
+      <div class="phase-banner">
+    % }
+  % } else {
     <div>
   % }
-<div class="small-text"><a href="http://resources.companieshouse.gov.uk/serviceInformation.shtml#compInfo" target="_blank">Companies House does not verify the accuracy of the information filed<span class="visuallyhidden">(link opens a new window)</span></a></div>
+
+% if ! $certified_copies {
+  <div class="small-text"><a href="http://resources.companieshouse.gov.uk/serviceInformation.shtml#compInfo" target="_blank">Companies House does not verify the accuracy of the information filed<span class="visuallyhidden">(link opens a new window)</span></a></div>
+% }
     </div>
 
     % if $user_bar != false {

--- a/templates/base.tx
+++ b/templates/base.tx
@@ -129,12 +129,13 @@
 			<!--<a href="#search" class="search-toggle js-header-toggle">Search</a>-->
 % }
         </div>
+        % if $certified_copies {
         <div>
-            <a href="/" title="Go to the Companies House homepage"<% if $c.config.piwik.embed { %> onClick="javascript:_paq.push(['trackEvent', 'CHLogo', 'Homepage']);"<% } %> id="service-logo" class="content">
+            <a href="/" title="Go to the Certified copies start page"<% if $c.config.piwik.embed { %> onClick="javascript:_paq.push(['trackEvent', 'Order a certified copy', 'Certified copies']);"<% } %> id="service-logo" class="content">
             Order a certified copy
           </a>
-          </div>
-
+        </div>
+        % }
       </div>
     </div>
   </header>

--- a/templates/base.tx
+++ b/templates/base.tx
@@ -64,6 +64,10 @@
 
    <!-- Companies House Styles and Scripts -->
 
+   % if $certified_copies {
+     <link href="//<% $cdn_url %>/stylesheets/gci/certified-copies.css" media="screen" rel="stylesheet" type="text/css">
+   % }
+
    <!--[if gt IE 8]><!--><link href="//<% $cdn_url %>/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css"><!--<![endif]-->
    <!--[if IE 6]><link href="//<% $cdn_url %>/stylesheets/application-ie6.css" media="screen" rel="stylesheet" type="text/css"><![endif]-->
    <!--[if IE 7]><link href="//<% $cdn_url %>/stylesheets/application-ie7.css" media="screen" rel="stylesheet" type="text/css"><![endif]-->
@@ -131,8 +135,8 @@
         </div>
         % if $certified_copies {
         <div>
-            <a href="/" title="Go to the Certified copies start page"<% if $c.config.piwik.embed { %> onClick="javascript:_paq.push(['trackEvent', 'Order a certified copy', 'Certified copies']);"<% } %> id="service-logo" class="content">
-            Order a certified copy
+            <a href="/" title="Go to the Certified copies start page"<% if $c.config.piwik.embed { %> onClick="javascript:_paq.push(['trackEvent', 'Order a certified document', 'Certified copies']);"<% } %> id="service-logo" class="govuk-header__link govuk-header__link--service-name">
+            Order a certified document
           </a>
         </div>
         % }

--- a/templates/company/filing_history/view_certified.html.tx
+++ b/templates/company/filing_history/view_certified.html.tx
@@ -47,7 +47,7 @@
      <script src='//<% $cdn_url %>/javascripts/vendor/application.js'></script>  <!-- Needed for new GDS-style radio buttons and checkboxes -->
 
 
-    % include '/includes/company/page_header.tx'
+    % include '/includes/company/certified_page_header.tx'
 
 % if $company.type == "uk-establishment" {
 <div class="grid-row">
@@ -138,7 +138,7 @@
 
         % } else {
                 <div id="filing-history-content">
-                    % include 'company/filing_history/view_content.html.tx'
+                    % include 'company/filing_history/view_content_certified.html.tx'
                 </div>
         % }
     %}

--- a/templates/company/filing_history/view_certified.html.tx
+++ b/templates/company/filing_history/view_certified.html.tx
@@ -1,0 +1,145 @@
+% cascade base { title => $company.company_name ~" - Filing history (free information from Companies House)", classes => "filing-history", require_js => "transactions/company/filing_history_view", disable_header_search => 1, certified_copies => 1, user_bar => false, insights_bar => false }
+%# a widget/block that allows a) "Show form type" to be toggled on/off b) results to be filtered by category
+% block category_console -> {
+        <form class="form">
+            <div class="form-group form-group-block">
+                <div class="block-label selection-button-checkbox">
+                    <label for="show-filing-type">
+                        <input
+                            id="show-filing-type"
+                            type="checkbox"<% $show_filing_type ? ' checked' : '' %> />
+                        <% l('Show filing type') %>
+                    </label>
+                </div>
+                <div class="form-group form-group-block filters">
+                    <h2 class="filter-by-category-heading">
+                        Filter by category
+                    </h2>
+                    <fieldset>
+                        <legend class="visuallyhidden">Filter by category</legend>
+                        % for $available_categories.kv() -> $category { # sorted by key
+                            % my $id   = $category.key;
+                            % my $name = $category.value;
+
+                            <div class="block-label selection-button-checkbox">
+
+                                <label for="filter-category-<% $id %>">
+                                    <input
+                                       id="filter-category-<% $id %>"
+                                       name="category"
+                                       value="<% $id %>"
+                                       type="checkbox"
+                                       <% $selected_categories[$id] ? 'checked' : '' %> />
+                                    <% l($name) %>
+                                </label>
+                            </div>
+                        % }
+                    </fieldset>
+                    <input id="submit-filter-by-category" class="button js-hidden" type="submit" value="<% l('Apply filter') %>"/>
+                </div>
+            </div>
+        </form>
+% }
+
+% around content -> {
+     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
+     <script src='//<% $cdn_url %>/javascripts/vendor/selection-buttons.js'></script> <!-- Needed for new GDS-style radio buttons and checkboxes -->
+     <script src='//<% $cdn_url %>/javascripts/vendor/application.js'></script>  <!-- Needed for new GDS-style radio buttons and checkboxes -->
+
+
+    % include '/includes/company/page_header.tx'
+
+% if $company.type == "uk-establishment" {
+<div class="grid-row">
+    <dl class="column-two-thirds">
+    <dt>
+    % l('Transactions are available from the filing history of the overseas company ')
+      </dt>
+      <dd class="text data" id="parent_company_link">
+<a href="<%'/company/' ~ $company.branch_company_details.parent_company_number ~ '/filing-history' %>" id="parent_number_link"><%($company.branch_company_details.parent_company_name)%></a>
+    </dd>
+      </dl>
+</div>
+% } else {
+    % if $company_filing_history.total_count > 0 || $selected_category_count > 0 {
+        <div class="js-only">
+            <form id="filing-history-filter" class="form grid-row font-xsmall">
+                <div class="column-quarter">
+                    <h2 class="heading-medium">Filter by category</h2>
+                    <label for="show-filing-type" class="block-label selection-button-checkbox">
+                        <input id="show-filing-type" type="checkbox"<% $show_filing_type ? ' checked' : '' %> />
+                        <strong><% l('Show filing type') %></strong>
+                    </label>
+                </div>
+                <br>
+                % if $disable_confirmation_statement_filter {
+                    <div class="column-third">
+                        <fieldset>
+                            <legend class="visuallyhidden">Confirmation statement filters</legend>
+                            % for $categories -> $category {
+                                % if $category.id == "confirmation-statement" {
+                                    <label for="filter-category-<% $category.id %>" class="block-label selection-button-checkbox selection-button-checkbox-small">
+                                        <input id="filter-category-<% $category.id %>" name="category" value="<% $category.id %>" type="checkbox" <% $category.checked ? 'checked' : '' %> />
+                                        <% l('Annual returns') %>
+                                    </label>
+                                % } else {
+                                    <label for="filter-category-<% $category.id %>" class="block-label selection-button-checkbox selection-button-checkbox-small">
+                                        <input id="filter-category-<% $category.id %>" name="category" value="<% $category.id %>" type="checkbox" <% $category.checked ? 'checked' : '' %> />
+                                        <% l($category.name) %>
+                                    </label>
+                                % }
+
+                                % if $~category.count == $split_category_at {
+                                    </div>
+                                    <div class="column-third">
+                                % }
+                            % }
+                        </fieldset>
+                        <input id="submit-filter-by-category" class="button js-hidden" type="submit" value="<% l('Apply filter') %>"/>
+                    </div>
+                % } else {
+                    <div class="column-quarter">
+                        <fieldset>
+                            <legend class="visuallyhidden">Confirmation statement filters</legend>
+                            % for $categories -> $category {
+                                <label for="filter-category-<% $category.id %>" class="block-label selection-button-checkbox selection-button-checkbox-small">
+                                    <input id="filter-category-<% $category.id %>" name="category" value="<% $category.id %>" type="checkbox" <% $category.checked ? 'checked' : '' %> />
+                                    <% l($category.name) %>
+                                </label>
+
+                                % if $~category.count == $split_category_at {
+                                    </div>
+                                    <div class="column-half">
+                                % }
+                            % }
+                        </fieldset>
+                        <input id="submit-filter-by-category" class="button js-hidden" type="submit" value="<% l('Apply filter') %>"/>
+                    </div>
+                % }
+            </form>
+        </div>
+    % }
+        % if $company_filing_history.total_count == 0 && $selected_category_count == 0 {
+            % my $fh_status = $company_filing_history.filing_history_status;
+
+            <p id="infoMessage" class="text">
+                <% tl( $c.fhe_lookup($fh_status )) %>
+            </p>
+            <%
+                if ( $fh_status == 'filing-history-available' ||
+                    $fh_status == 'filing-history-available-no-images-limited-partnership-from-1988' ||
+                    $fh_status == 'filing-history-available-limited-partnership-from-2014' ||
+                    $fh_status == 'filing-history-available-assurance-company-before-2004' ) {
+            %>
+                <p id="noFilingsMessage" class="text">
+                    <% l('Sorry, no filings are available for this company.') %>
+                </p>
+                % }
+
+        % } else {
+                <div id="filing-history-content">
+                    % include 'company/filing_history/view_content.html.tx'
+                </div>
+        % }
+    %}
+% }

--- a/templates/company/filing_history/view_content_certified.html.tx
+++ b/templates/company/filing_history/view_content_certified.html.tx
@@ -1,0 +1,122 @@
+%# this mini-macro returns a (space-prefixed) class list which handles the boilerplate of associating
+%# an element's visibility with the "Show filing type" checkbox.
+%# TODO for sprintf (and other Perl builtins): add Text::Xslate::Bridge::Star to CH::MojoX::Plugin::Xslate
+% macro sft_toggled -> { ' sft-toggled' ~ ($show_filing_type ? '' : ' js-hidden') }
+
+% if $company_filing_history.total_count == 0 { # no results
+    <p class="text">
+        <% tl( $c.fhe_lookup($company_filing_history.filing_history_status) ) %>
+    </p>
+    <p class="text">
+        <%
+            ln(
+                'Sorry, no filings in the selected category are available for this company.',
+                'Sorry, no filings in the selected categories are available for this company.',
+                $selected_category_count
+            )
+        %>
+    </p>
+% } else { # results
+    <p class="text">
+        <% tl( $c.fhe_lookup($company_filing_history.filing_history_status) ) %>
+    </p>
+    <table id="fhTable" class="full-width-table">
+        <caption class="visuallyhidden">Company Results (links open in a new window)</caption>
+        <tr>
+            <th>
+                Select
+            </th>
+            <th class="nowrap">
+                Date filed<span class="visuallyhidden">(document was filed at Companies House)</span>
+            </th>
+            <th class="filing-type<% sft_toggled() %>">
+                Type
+            </th>
+            <th>
+                Description <span class="visuallyhidden">(of the document filed at Companies House)</span>
+            </th>
+            % if ( $image_service_active ) {
+                <th class="nowrap">
+                    Fee <span class="visuallyhidden">(PDF file, link opens in new window)</span>
+                </th>
+            % }
+        </tr>
+        % for $company_filing_history.items -> $item {
+            <tr>
+                <td>
+                <div class="block-label selection-button-checkbox">
+                    <label for="filter-category-<% $id %>">
+                        <input
+                        id="filter-category-<% $id %>"
+                        name="category"
+                        value="<% $id %>"
+                        type="checkbox"
+                        <% $selected_categories[$id] ? 'checked' : '' %> />
+                        <% l($name) %>
+                    </label>
+                </div>
+                <br>
+                <br>
+                </td>
+                <td class="nowrap">
+                    % $c.isodate_as_short_string($item.date)
+                </td>
+                <td class="filing-type<% sft_toggled() %>">
+                    % $item.type
+                </td>
+                <td>
+                    % include "company/filing_history/transaction_description.html.tx" { item => $item };
+                    % if !$item.links.document_metadata {
+                      % if ($item._missing_message == 'unavailable') {
+                      <div class="form-hint">
+			      <!--This document is not available online but it may be possible to order a copy from the Contact Centre. Telephone +44(0)303 1234 500.-->
+                  Due to the impact of Covid 19 we are currently unable to offer the document ordering service for older documents not shown on the filing history of Companies House Service.
+                      </div>
+                      % }
+                      % if ($item._missing_message == 'available_in_5_days') {
+                      <div class="form-hint">
+                        This document is being processed and will be available in 5 days.
+                      </div>
+                      % }
+                    % }
+                </td>
+                <td class="nowrap">
+                    £15
+                </td>
+                % }
+            </tr>
+        % }
+    </table>
+
+    % if $company_filing_history.total_count > $entries_per_page {
+            <ul class="pager">
+                % if ($previous_page) {
+                    <li>
+                        <a id="previousButton" class="page" href="<% $c.url_with.query([ page => $previous_page ]) %>" data-page="<% $previous_page %>">
+                            Previous
+                        </a>
+                    </li>
+                % }
+                % for $page_set -> $page {
+                    <li>
+                        <a id="pageNo<% $page %>" class="page" href="<% $c.url_with.query([ page => $page ]) %>" data-page="<% $page %>">
+                            % if $current_page_number == $page {
+                                <strong>
+                                    <% $page %>
+                                </strong>
+                            % } else {
+                                <% $page %>
+                            % }
+                        </a>
+                    </li>
+                % }
+                % if ($next_page) {
+                    <li>
+                        <a id="nextButton" class="page" href="<% $c.url_with.query([ page => $next_page ]) %>" data-page="<% $next_page %>">
+                            Next
+                        </a>
+                    </li>
+                % }
+            </ul>
+    % }
+% }

--- a/templates/company/filing_history/view_content_certified.html.tx
+++ b/templates/company/filing_history/view_content_certified.html.tx
@@ -81,7 +81,11 @@
                     % }
                 </td>
                 <td class="nowrap">
+                % if $item.type == "NEWINC" {
+                    £30
+                % } else {
                     £15
+                % }
                 </td>
                 % }
             </tr>

--- a/templates/includes/company/certified_page_header.tx
+++ b/templates/includes/company/certified_page_header.tx
@@ -1,9 +1,7 @@
 <div class="company-header">
         <div id="content" class="content-override"></div>
         <a href="/" class="govuk-back-link">Back</a>
-        <br>
-        <p class="heading-xlarge">Add documents to order</p>
-        <br>
+        <p class="heading-xlarge" id="add-document-heading">Add documents to order</p>
         <p class="heading-large"><% $company.company_name %></p>
         <p id="company-number">
         % if $company.type == 'uk-establishment' {
@@ -14,6 +12,12 @@
           % }
             <strong><% $company.company_number %></strong>
         </p>
+
+        <div class="govuk-inset-text">
+            <h2 class="heading-m" id="documentsSelectedCountTop">No documents selected</h2>
+        <ul id="documentsSelectedList" class="govuk-list govuk-list--bullet">
+        </ul>
+        </div>
 
         <a href="/" class="button" id="add-documents-to-order"
           % if $c.config.piwik.embed {

--- a/templates/includes/company/certified_page_header.tx
+++ b/templates/includes/company/certified_page_header.tx
@@ -1,0 +1,25 @@
+<div class="company-header">
+        <div id="content" class="content-override"></div>
+        <a href="/" class="govuk-back-link">Back</a>
+        <br>
+        <p class="heading-xlarge">Add documents to order</p>
+        <br>
+        <p class="heading-large"><% $company.company_name %></p>
+        <p id="company-number">
+        % if $company.type == 'uk-establishment' {
+        <% l('UK establishment number') %>
+        % }
+        % else {
+            <% l('Company number') %>
+          % }
+            <strong><% $company.company_number %></strong>
+        </p>
+
+        <a href="/" class="button" id="add-documents-to-order"
+          % if $c.config.piwik.embed {
+          onclick="javascript:_paq.push(['trackEvent', 'AddDocumentsToOrder']);"
+        % }
+        ><% l('Add documents to order') %>
+        </a>
+</div>
+<br>


### PR DESCRIPTION
Reuse filing history code required to add new skeleton screen for certified documents which will provide a filing history of a company to the user to select which certified documents they wish to order.

CDN Changes: https://github.com/companieshouse/cdn.ch.gov.uk/pull/400

Resolves: GCI-1153

<img width="544" alt="Screenshot 2020-06-11 at 16 17 54" src="https://user-images.githubusercontent.com/24222489/84404888-4e7c4a80-abff-11ea-931b-24f2aadef63b.png">