### PR TITLE
Accessibility Audit - Change ROA and Register of Disqualifications

### DIFF
--- a/templates/company/transactions/transaction.tx
+++ b/templates/company/transactions/transaction.tx
@@ -1,10 +1,10 @@
-% cascade base { title => $title, form_page => 1, }
+% cascade base { title => $title, form_page => 1, alternative_skiplink => true }
 % around content -> {
 
     % include "company/transactions/filing_for.html.tx"
 
 	<header class="text">
-		<h1 class="heading-xlarge"><% $title %></h1>
+		<h1 class="heading-xlarge" id="page-content"><% $title %></h1>
 		% block additional_header -> {}
 	</header>
 

--- a/templates/includes/forms/select_field.html.tx
+++ b/templates/includes/forms/select_field.html.tx
@@ -1,7 +1,7 @@
 % if !$no_errors {
     <div class="form-group <% if $has_errors { %>error <%} %>">
     <a name="<% $errors[0].id %>"></a>
-    <label class="form-label form-label-bold">
+    <label for="<% $id %>" class="form-label form-label-bold">
     <% $label %>
     % if $has_errors {
     %   for $errors->$error {

--- a/templates/register_of_disqualifications/list.html.tx
+++ b/templates/register_of_disqualifications/list.html.tx
@@ -1,10 +1,10 @@
-% cascade base { title => 'Register Of Disqualifications - ' ~ $active_letter, disable_header_search => 1 }
+% cascade base { title => 'Register Of Disqualifications - ' ~ $active_letter, disable_header_search => 1, alternative_skiplink => true }
 
 % around content -> {
 
        <div class="active">
             <header>
-                <h1 class="heading-xlarge">Register of disqualifications</h1>
+                <h1 class="heading-xlarge" id="page-content">Register of disqualifications</h1>
             </header>
 
             <ul class="pager pager-a-z" id="alphabetical-pager">


### PR DESCRIPTION
To make sure the accessibility statement is applicable for the change of roa and register of disqualifications page, some fixes where required. This includes fixing broken skiplinks and adding a missing label to a form action
Resolves: CB-1108