### PR TITLE
Ensure documents with associated images are orderable and remove cost for unorderable documents

### DIFF
--- a/templates/company/filing_history/view_content_certified.html.tx
+++ b/templates/company/filing_history/view_content_certified.html.tx
@@ -45,7 +45,7 @@
         % for $company_filing_history.items -> $item {
             <tr>
                 <td>
-                % if !($item._missing_message == 'unavailable') && !($item._missing_message == 'available_in_5_days') {
+                % if !($item._missing_message == 'unavailable') && !($item._missing_message == 'available_in_5_days') || $item.links.document_metadata  {
                 <div class="govuk-checkboxes__item">
                 <label for="checkbox-<% $item.transaction_id %>">
                 <input
@@ -88,13 +88,14 @@
                     % }
                 </td>
                 <td class="nowrap">
-                % if $item.type == "NEWINC" {
-                    £30
-                % } else {
-                    £15
+                % if !($item._missing_message == 'unavailable') && !($item._missing_message == 'available_in_5_days') || $item.links.document_metadata  {
+                    % if $item.type == "NEWINC" {
+                        £30
+                    % } else {
+                        £15
+                    % }
                 % }
                 </td>
-                % }
             </tr>
         % }
     </table>


### PR DESCRIPTION
- Enable the ability to order a document that is before the `unavailable_date` that has a associated image that has been scanned
- Remove cost for documents that are not available for order
Resolves: GCI-1354, GCI-1355