### PR TITLE
Add Request Document Button for SCUD Orders

### DIFF
--- a/appconfig.yml
+++ b/appconfig.yml
@@ -96,6 +96,7 @@ feature:
     alphabetical_search: <ALPHABETICAL_SEARCH_FEATURE>
     order_certificate: <ORDER_CERTIFICATE_FEATURE>
     order_certified_document: <ORDER_CERTIFIED_DOCUMENT_FEATURE>
+    scan_upon_demand: <SCAN_UPON_DEMAND_FEATURE>
 
 image_service_start_date: <IMAGE_SERVICE_START_DATE>
 

--- a/templates/company/filing_history/view_content.html.tx
+++ b/templates/company/filing_history/view_content.html.tx
@@ -74,7 +74,9 @@
                             <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'xhtml', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]);"<% } %>>Download iXBRL</a></div>
                         % }
                     % } else if $item._missing_message != 'available_in_5_days' {
-                        <a href="orderable/scan-upon-demand/<% $item.transaction_id %>" class="normal piwik-event" data-event-id="Request Document">Request Document</a>
+                         % if $c.config.feature.scan_upon_demand {
+                            <a href="orderable/scan-upon-demand/<% $item.transaction_id %>" class="normal piwik-event" data-event-id="Request Document">Request Document</a>
+                         % }
                     % }
                     </td>
                 % }

--- a/templates/company/filing_history/view_content.html.tx
+++ b/templates/company/filing_history/view_content.html.tx
@@ -73,6 +73,8 @@
                         <div>
                             <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'xhtml', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]);"<% } %>>Download iXBRL</a></div>
                         % }
+                    % } else {
+                        <a href="orderable/scan-upon-demand/<% $item.transaction_id %>" class="normal piwik-event" data-event-id="Request Document">Request Document</a>
                     % }
                     </td>
                 % }

--- a/templates/company/filing_history/view_content.html.tx
+++ b/templates/company/filing_history/view_content.html.tx
@@ -73,7 +73,7 @@
                         <div>
                             <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'xhtml', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]);"<% } %>>Download iXBRL</a></div>
                         % }
-                    % } else {
+                    % } else if $item._missing_message != 'available_in_5_days' {
                         <a href="orderable/scan-upon-demand/<% $item.transaction_id %>" class="normal piwik-event" data-event-id="Request Document">Request Document</a>
                     % }
                     </td>


### PR DESCRIPTION
When a filing history document is not available to view/download due to it never being scanned an option is available to order a document.

Resolves: GCI-220