### PR TITLE
Fix filters mobile styling

### DIFF
--- a/templates/company/filing_history/view_certified.html.tx
+++ b/templates/company/filing_history/view_certified.html.tx
@@ -62,7 +62,7 @@
 % } else {
     % if $company_filing_history.total_count > 0 || $selected_category_count > 0 {
         <div class="js-only">
-            <div id="filing-history-filter" class="form grid-row font-xsmall">
+            <form id="filing-history-filter" class="form grid-row font-xsmall">
                 <div class="column-quarter">
                     <h2 class="heading-medium">Filter by category</h2>
                     <label for="show-filing-type" class="block-label selection-button-checkbox">
@@ -117,7 +117,7 @@
                         <input id="submit-filter-by-category" class="button js-hidden" type="submit" value="<% l('Apply filter') %>"/>
                     </div>
                 % }
-            </div>
+            </form>
         </div>
     % }
         % if $company_filing_history.total_count == 0 && $selected_category_count == 0 {


### PR DESCRIPTION
With the previous checkbox solution the main content of the page was nested inside a `<form>` element, therefore the filters were changed to use a `<div>`. Since moving to a single order the page is no longer inside a form, the form element provides some level of styling. This revert fixes the mobile styling issue that regressed due to the content not being inside a form.