### PR TITLE
Update feature flag and url to be missing image delivery

### DIFF
--- a/appconfig.yml
+++ b/appconfig.yml
@@ -96,7 +96,7 @@ feature:
     alphabetical_search: <ALPHABETICAL_SEARCH_FEATURE>
     order_certificate: <ORDER_CERTIFICATE_FEATURE>
     order_certified_document: <ORDER_CERTIFIED_DOCUMENT_FEATURE>
-    scan_upon_demand: <SCAN_UPON_DEMAND_FEATURE>
+    missing_image_delivery: <MISSING_IMAGE_DELIVERY_FEATURE>
 
 image_service_start_date: <IMAGE_SERVICE_START_DATE>
 

--- a/templates/company/filing_history/view_content.html.tx
+++ b/templates/company/filing_history/view_content.html.tx
@@ -74,8 +74,8 @@
                             <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'xhtml', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]);"<% } %>>Download iXBRL</a></div>
                         % }
                     % } else if $item._missing_message != 'available_in_5_days' {
-                         % if $c.config.feature.scan_upon_demand {
-                            <a href="orderable/scan-upon-demand/<% $item.transaction_id %>" class="normal piwik-event" data-event-id="Request Document">Request Document</a>
+                         % if $c.config.feature.missing_image_delivery {
+                            <a href="orderable/missing-image-delivery/<% $item.transaction_id %>" class="normal piwik-event" data-event-id="Request Document">Request Document</a>
                          % }
                     % }
                     </td>


### PR DESCRIPTION
Replace references of scan upon demand to be missing image delivery

Resolves: GCI-1478

Dependent on PR: https://github.com/companieshouse/chs-configs/pull/1229