### PR TITLE
Gci 1204 update more tab for dissolved certificates

### DIFF
--- a/lib/ChGovUk/Controllers/Company/ViewAll.pm
+++ b/lib/ChGovUk/Controllers/Company/ViewAll.pm
@@ -66,7 +66,7 @@ sub view {
       $show_certified_document = 0;
   }
 
-  if ($company_status eq 'liquidation' || $company_status eq 'dissolved') {
+  if ($company_status eq 'dissolved') {
     $show_dissolved_certificate = 1;
   }
 

--- a/lib/ChGovUk/Controllers/Company/ViewAll.pm
+++ b/lib/ChGovUk/Controllers/Company/ViewAll.pm
@@ -46,6 +46,7 @@ sub view {
   my $show_snapshot = 1;
   my $show_orders = 0;
   my $show_certified_document = 1;
+  my $show_dissolved_certificate = 0;
 
   for (my $i=0; $i < @snapshot_company_types; $i++) {
     if ($company_type eq $snapshot_company_types[$i]) {
@@ -58,18 +59,23 @@ sub view {
       if ($company_type eq $orders_company_types[$j]) {
         $show_orders = 1;
       }
-    } 
+    }
   }
 
   if ($filing_history eq "" || ($filing_history ne "" && $company_type eq "uk-establishment")) {
       $show_certified_document = 0;
   }
 
+  if ($company_status eq 'liquidation' || $company_status eq 'dissolved') {
+    $show_dissolved_certificate = 1;
+  }
+
   $self->stash(show_snapshot => $show_snapshot);
   $self->stash(show_orders => $show_orders);
   $self->stash(show_certified_document => $show_certified_document);
+  $self->stash(show_dissolved_certificate => $show_dissolved_certificate);
 
-  if ($show_snapshot || $show_orders || $show_certified_document) {
+  if ($show_snapshot || $show_orders || $show_certified_document || $show_dissolved_certificate) {
     return $self->render(template => 'company/view_all/view');
   } else {
     return $self->render(template => 'not_found.production');

--- a/lib/ChGovUk/Controllers/Company/ViewAll.pm
+++ b/lib/ChGovUk/Controllers/Company/ViewAll.pm
@@ -20,7 +20,7 @@ use CH::Perl;
     "icvc-warrant",
     "icvc-umbrella");
 
-  my @orders_company_types = (
+  my @certificate_orders_company_types = (
     "limited-partnership",
     "llp",
     "ltd",
@@ -31,6 +31,17 @@ use CH::Perl;
     "private-limited-shares-section-30-exemption",
     "private-unlimited",
     "private-unlimited-nsc");
+
+  my @dissolved_certificate_orders_company_types = (
+      "llp",
+      "ltd",
+      "plc",
+      "old-public-company",
+      "private-limited-guarant-nsc",
+      "private-limited-guarant-nsc-limited-exemption",
+      "private-limited-shares-section-30-exemption",
+      "private-unlimited",
+      "private-unlimited-nsc");
 
 #-------------------------------------------------------------------------------
 
@@ -44,7 +55,7 @@ sub view {
   my $links = $company->{links};
   my $filing_history = $links->{filing_history};
   my $show_snapshot = 1;
-  my $show_orders = 0;
+  my $show_certificate = 0;
   my $show_certified_document = 1;
   my $show_dissolved_certificate = 0;
 
@@ -55,9 +66,9 @@ sub view {
   }
 
   if ($company_status eq 'active') {
-    for (my $j=0; $j < @orders_company_types; $j++) {
-      if ($company_type eq $orders_company_types[$j]) {
-        $show_orders = 1;
+    for (my $j=0; $j < @certificate_orders_company_types; $j++) {
+      if ($company_type eq $certificate_orders_company_types[$j]) {
+        $show_certificate = 1;
       }
     }
   }
@@ -67,15 +78,19 @@ sub view {
   }
 
   if ($company_status eq 'dissolved') {
-    $show_dissolved_certificate = 1;
+    for (my $j=0; $j < @dissolved_certificate_orders_company_types; $j++) {
+      if ($company_type eq $dissolved_certificate_orders_company_types[$j]) {
+        $show_dissolved_certificate = 1;
+      }
+    }
   }
 
   $self->stash(show_snapshot => $show_snapshot);
-  $self->stash(show_orders => $show_orders);
+  $self->stash(show_certificate => $show_certificate);
   $self->stash(show_certified_document => $show_certified_document);
   $self->stash(show_dissolved_certificate => $show_dissolved_certificate);
 
-  if ($show_snapshot || $show_orders || $show_certified_document || $show_dissolved_certificate) {
+  if ($show_snapshot || $show_certificate || $show_certified_document || $show_dissolved_certificate) {
     return $self->render(template => 'company/view_all/view');
   } else {
     return $self->render(template => 'not_found.production');

--- a/templates/company/view_all/view.html.tx
+++ b/templates/company/view_all/view.html.tx
@@ -75,6 +75,26 @@
       </details>
         <a class="govuk-button secondary-button piwik-event" data-event-id="Order a certificate" href="orderable/certificates">Order certificate</a>
     % }
+    % if $show_dissolved_certificate {
+      <h2 id="order-a-certificate-header" class="heading-large heading-with-border">
+        Order a certificate
+      </h2>
+      <details class="govuk-details" role="group">
+        <summary class="govuk-details__summary" role="button" aria-controls="details-content" aria-expanded="true">
+          <span class="govuk-details__summary-text">
+            What you'll need
+          </span>
+        </summary>
+        <div class="govuk-details__text" id="order-a-certificate-details-content" aria-hidden="false">
+          <p id="orders-list">To use the service, you'll need:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>the address you want the certificate to be delivered to (UK or international)</li>
+            <li>a credit or debit card for payment</li>
+          </ul>
+        </div>
+      </details>
+        <a class="govuk-button secondary-button piwik-event" data-event-id="Order a dissolved certificate" href="orderable/dissolved-certificates">Order certificate</a>
+    % }
   %}
 
   % if $c.config.feature.order_certified_document {

--- a/templates/company/view_all/view.html.tx
+++ b/templates/company/view_all/view.html.tx
@@ -54,7 +54,7 @@
   % }
 
   % if $c.config.feature.order_certificate {
-    % if $show_orders {
+    % if $show_certificate {
       <h2 id="order-a-certificate-header" class="heading-large heading-with-border">
         Order a certificate
       </h2>
@@ -93,7 +93,7 @@
           </ul>
         </div>
       </details>
-        <a class="govuk-button secondary-button piwik-event" data-event-id="Order a dissolved certificate" href="orderable/dissolved-certificates">Order certificate</a>
+        <a class="govuk-button secondary-button piwik-event" data-event-id="Order a dissolved certificate" href="orderable/certificates">Order certificate</a>
     % }
   %}
 


### PR DESCRIPTION
The order a certificate option on the more tab will now dynamically output the correct information within the what you'll need drop down when a company status is dissolved and has a company type which allows the ordering of a dissolved certificate.

Resolves: GCI-1204