### PR TITLE
Use DOCKER_BUILDKIT=0 flag for Docker builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ Docker support
 Pull image from private CH registry by running `docker pull 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/ch.gov.uk:latest` command or run the following steps to build image locally:
 
 1. `make` (only once to clone submodules and pull dependencies)
-2. `docker build -t 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/ch.gov.uk:latest .`
+2. `DOCKER_BUILDKIT=0 docker build -t 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/ch.gov.uk:latest .`


### PR DESCRIPTION
Docker releases >=2.4.0.0 have BuildKit enabled by default - this breaks image builds due to a known issue (https://github.com/moby/buildkit/issues/816) with BuildKit and ONBUILD COPY --from directives which we use in our runtime image.

Prefixing `docker build` commands with `DOCKER_BUILDKIT=0` fixes the issue