### PR TITLE
Add new link type for zip filings to filinghistory

### DIFF
--- a/templates/company/filing_history/view_content.html.tx
+++ b/templates/company/filing_history/view_content.html.tx
@@ -71,6 +71,10 @@
                 % if $image_service_active {
                     <td class="nowrap">
                     % if $item.links.document_metadata {
+                     % if (!$item.paper_filed && $item.type == 'AA' && $item.pages == 9999) {
+                        <div>
+                            <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'zip', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]);"<% } %>>Download ZIP</a></div>
+                     % } else {
                     <div>
                         <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'pdf', download => 0) %>" target="_blank" class="download" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 2]);"<% } %>>View PDF
                         <span class="visuallyhidden"><% include "company/filing_history/transaction_description.html.tx" { item => $item } %> - link opens in a new window <% if ($item.pages) { %> - <% ln('%d page', '%d pages', $item.pages) } %></span></a>
@@ -79,6 +83,7 @@
                         <div>
                             <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'xhtml', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]);"<% } %>>Download iXBRL</a></div>
                         % }
+                    % }
                     % } else if ($item._missing_message != 'available_in_5_days' && !$item._missing_doc) {
                          % if $c.config.feature.missing_image_delivery {
                             <a href="orderable/missing-image-deliveries/<% $item.transaction_id %>" class="normal piwik-event" data-event-id="Request Document">Request Document</a>

--- a/templates/company/transactions/document_download.html.tx
+++ b/templates/company/transactions/document_download.html.tx
@@ -43,6 +43,11 @@
                             <a href="<% $c.url_for('document_download', id => $item._document_id, document_type => 'xhtml') %>">XHTML</a>
                         </li>
                     % }
+                    % if ($metadata.resources['application/zip']) {
+                        <li id="zip">
+                            <a href="<% $c.url_for('document_download', id => $item._document_id, document_type => 'zip') %>">ZIP</a>
+                        </li>
+                    % }
                 </ul>
             %}
 


### PR DESCRIPTION
New functionality has been added to the filing history
template to now allow the downloading of zip file types.

Currently we identify zip accounts via their unique page
count of 9999. This was decided as an initial implentation
which will be properly implenented with a more elegant
soltion in the near future.