### PR TITLE
Filing History Content Type

### DIFF
--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -201,6 +201,9 @@ sub view {
 #-------------------------------------------------------------------------------
 
 # _get_content_type calls the document API and retrieves a content_type for the provided filing.
+# Please note - this function grabs the first variable returned from the resources array and only uses it
+# in the template if it is application/zip (zip filing). Changes would be required if you wanted to use
+# other resource types returned in the template. If you want to return multiple changes would also be required to cater for this.
 sub _get_content_type {
     my ( $self, $document_metadata_uri, $doc, $callback ) = @_;
 

--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -213,17 +213,6 @@ sub view {
                     my $fileType = $tx->res->headers->type;
                     trace "---------------- fileType:";
                     trace $fileType;
-                    my $location = $tx->res->headers->location;
-
-                    if ($location) {
-                        $next->($location);
-                    }
-                    else {
-                        $delay->emit('error', sprintf(
-                            'Failed to get redirect from Document API, document_metadata [%s]',
-                            $document_metadata_uri,
-                        ));
-                    }
                 }
             )->execute;
         },

--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -98,12 +98,6 @@ sub view {
  
     my $xhtml_available_date = $self->config->{xhtml_available_date} || '2015-06-01';
 
-    my $delay = Mojo::IOLoop->delay;
-
-    $delay->steps(
-        sub {
-            my ($delay) = @_;
-            my $next = $delay->begin(0);
     # Get the filing history for the company from the API
     $self->ch_api->company($self->stash('company_number'))->filing_history($query)->force_api_key(1)->get->on(
         success => sub {
@@ -112,7 +106,9 @@ sub view {
             trace "filing history for %s: %s", $self->stash('company_number'), d:$fh_results [FILING_HISTORY];
             for my $doc (@{$fh_results->{items}}) {
                 if (defined $doc->{links}->{document_metadata}) {
-                    $next->($doc->{links}->{document_metadata});
+                    # $next->($doc->{links}->{document_metadata});
+                    my $content_type = $self->_get_content_type($doc->{links}->{document_metadata});
+                    trace "--------------------- Content type: [%s]", $content_type;
                 }
                 my $transaction_date = $doc->{date};
                 my $formatted_transaction_date = date_convert($transaction_date);
@@ -173,53 +169,48 @@ sub view {
             $self->render_exception("Error retrieving company: $error");
         }
       )->execute;
-  },
-  sub {
-      my ($delay, $document_metadata_uri) = @_;
-            my $next = $delay->begin(0);
-
-            $self->ch_api->document($document_metadata_uri)->metadata->get->on(
-                failure => sub {
-                    my ($api, $tx) = @_;
-                    my $code = $tx->error->{code} // 0;
-
-                    if ($code == 404) {
-                        $delay->emit('not_found', $document_metadata_uri);
-                    }
-                    else {
-                        $delay->emit('error', sprintf(
-                            'Failure fetching document for company_number [%s] filing_history_id [%s]: %d [%s]',
-                            $self->stash->{company_number},
-                            $self->stash->{filing_history_id},
-                            $code,
-                            $tx->error->{message},
-                        ));
-                    }
-                },
-                error => sub {
-                    my ($api, $err) = @_;
-
-                    $delay->emit('error', sprintf(
-                        'Error fetching document for company_number [%s] filing_history_id [%s]: [%s]',
-                        $self->stash->{company_number},
-                        $self->stash->{filing_history_id},
-                        $err,
-                    ));
-                },
-                success => sub {
-                    my ($api, $tx) = @_;
-
-                    trace "TRANSACTION: %s", d:$tx [DOCUMENT];
-                    my $fileType = $tx->res->headers->type;
-                    trace "---------------- fileType:";
-                    trace $fileType;
-                }
-            )->execute;
-        },
-    );
 
     $self->render_later;
 }
+
+#-------------------------------------------------------------------------------
+
+sub _get_content_type {
+    my ( $self, $document_metadata_uri ) = @_;
+
+    warn $document_metadata_uri;
+    $self->ch_api->document($document_metadata_uri)->metadata->get->on(
+        failure => sub {
+            my ($api, $tx) = @_;
+            my $code = $tx->error->{code} // 0;
+
+            if ($code == 404) {
+                error "Content Type not found for %s: %s", $document_metadata_uri, $code;
+                return;
+            }
+            else {
+                error "Error fetching Content Type for %s: %s", $document_metadata_uri, $tx->error->{message};
+                return;
+            }
+        },
+        error => sub {
+            my ($api, $err) = @_;
+            error "Error fetching Content Type for %s: %s", $document_metadata_uri, $err;
+            return;
+        },
+        success => sub {
+            my ($api, $tx) = @_;
+
+            my $fileType = $tx->res->headers->type;
+            trace "---------------- fileType:";
+            trace $fileType;
+            return $tx->res->headers->type;
+        }
+
+      )->execute;
+    }
+
+#-------------------------------------------------------------------------------
 
 sub date_convert {
   my ($original_date) = @_;

--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -193,8 +193,6 @@ sub view {
 sub _get_content_type {
     my ( $self, $document_metadata_uri, $doc, $callback ) = @_; # based on mortage.pm
 
-    $document_metadata_uri = "http://document-api.rebel1.aws.chdev.org/document/TryHzSUvNuHiCYUAtcBE4xCiuD3hZmgAJt3HGm2c0Q4";
-
     $self->ch_api->document($document_metadata_uri)->metadata->get->on(
         failure => sub {
             my ($api, $tx) = @_;

--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -197,7 +197,7 @@ sub _get_content_type {
         failure => sub {
             my ($api, $tx) = @_;
             my $code = $tx->error->{code} // 0;
-
+            $doc->{content_type} = 'unknown';
             if ($code == 404) {
                 error "Content Type not found for %s: %s", $document_metadata_uri, $code;
                 return $callback->(0);
@@ -209,6 +209,7 @@ sub _get_content_type {
         },
         error => sub {
             my ($api, $err) = @_;
+            $doc->{content_type} = 'unknown';
             error "Error fetching Content Type for %s: %s", $document_metadata_uri, $err;
             return $callback->(0);
         },

--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -178,7 +178,6 @@ sub view {
 sub _get_content_type {
     my ( $self, $document_metadata_uri ) = @_;
 
-    warn $document_metadata_uri;
     $self->ch_api->document($document_metadata_uri)->metadata->get->on(
         failure => sub {
             my ($api, $tx) = @_;
@@ -201,10 +200,9 @@ sub _get_content_type {
         success => sub {
             my ($api, $tx) = @_;
 
-            my $fileType = $tx->res->headers->type;
-            trace "---------------- fileType:";
-            trace $fileType;
-            return $tx->res->headers->type;
+            my $resources = $tx->res->json->{resources};
+            warn (keys $resources)[0];
+            return (keys $resources)[0];
         }
 
       )->execute;

--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -200,24 +200,24 @@ sub _get_content_type {
 
             if ($code == 404) {
                 error "Content Type not found for %s: %s", $document_metadata_uri, $code;
-                return;
+                return $callback->(0);
             }
             else {
                 error "Error fetching Content Type for %s: %s", $document_metadata_uri, $tx->error->{message};
-                return;
+                return $callback->(0);
             }
         },
         error => sub {
             my ($api, $err) = @_;
             error "Error fetching Content Type for %s: %s", $document_metadata_uri, $err;
-            return;
+            return $callback->(0);
         },
         success => sub {
             my ($api, $tx) = @_;
 
             my $resources = $tx->res->json->{resources};
             $doc->{_content_type} = (keys $resources)[0];
-            $callback->(0);
+            return $callback->(0);
         }
 
     )->execute;

--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -130,7 +130,7 @@ sub view {
                         }
 
                         if ( $formatted_transaction_date >= $formatted_xhtml_available_date) {
-                            $doc->{_xhtml_is_available} = 1 ;
+                            $doc->{_xhtml_is_available} = 1;
                         }
 
                         # Generate a missing message for documents before a defined unavailable date

--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -111,7 +111,7 @@ sub view {
                 sub {
                     my ($delay) = @_;
                     for my $doc (@{$fh_results->{items}}) {
-                        if (defined $doc->{links}->{document_metadata}) {
+                        if (defined $doc->{links}->{document_metadata} && $doc->{type} eq 'AA' && $doc->{pages} > 0) {
 
                             my $delay_end = $delay->begin(0);
                             $self->_get_content_type( $doc->{links}->{document_metadata}, $doc, $delay_end);

--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -206,6 +206,7 @@ sub view {
 # Please note - this function grabs the first variable returned from the resources array and only uses it
 # in the template if it is application/zip (zip filing). Changes would be required if you wanted to use
 # other resource types returned in the template. If you want to return multiple changes would also be required to cater for this.
+# This future work has been documented in a ticket on JIRA: https://companieshouse.atlassian.net/browse/UK-155.
 sub _get_content_type {
     my ( $self, $document_metadata_uri, $doc, $callback ) = @_;
 

--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -216,7 +216,7 @@ sub _get_content_type {
             my ($api, $tx) = @_;
 
             my $resources = $tx->res->json->{resources};
-            $doc->{_content_type} = (keys $resources)[0];
+            $doc->{content_type} = (keys $resources)[0];
             return $callback->(0);
         }
 

--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -162,6 +162,8 @@ sub view {
             $pager->total_entries, $pager->entries_per_page() [FILING_HISTORY];
 
             $delay->on(
+                # Must wait for delay to finish before stashing data,
+                # as all calls to the Document API must be complete.
                 finish => sub {
                     $self->stash(current_page_number     => $pager->current_page);
                     $self->stash(page_set                => $pager->pages_in_set());

--- a/lib/ChGovUk/Controllers/Company/FilingHistory.pm
+++ b/lib/ChGovUk/Controllers/Company/FilingHistory.pm
@@ -191,7 +191,7 @@ sub view {
 #-------------------------------------------------------------------------------
 
 sub _get_content_type {
-    my ( $self, $document_metadata_uri, $doc, $callback ) = @_; # based on mortage.pm
+    my ( $self, $document_metadata_uri, $doc, $callback ) = @_;
 
     $self->ch_api->document($document_metadata_uri)->metadata->get->on(
         failure => sub {

--- a/templates/company/filing_history/view_content.html.tx
+++ b/templates/company/filing_history/view_content.html.tx
@@ -71,7 +71,9 @@
                 % if $image_service_active {
                     <td class="nowrap">
                     % if $item.links.document_metadata {
-                     % if ($item.content_type == 'application/zip') {
+                     % if ($item.content_type == 'unknown') {
+                            <!--Skip any logic for unknown content_types, as we don't know what link they would need.-->
+                     % } else if ($item.content_type == 'application/zip') {
                         <div>
                             <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'zip', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]);"<% } %>>Download ZIP</a></div>
                      % } else {

--- a/templates/company/filing_history/view_content.html.tx
+++ b/templates/company/filing_history/view_content.html.tx
@@ -71,7 +71,7 @@
                 % if $image_service_active {
                     <td class="nowrap">
                     % if $item.links.document_metadata {
-                     % if ($item._content_type == 'application/zip') {
+                     % if ($item.content_type == 'application/zip') {
                         <div>
                             <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'zip', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]);"<% } %>>Download ZIP</a></div>
                      % } else {

--- a/templates/company/filing_history/view_content.html.tx
+++ b/templates/company/filing_history/view_content.html.tx
@@ -70,8 +70,11 @@
                 </td>
                 % if $image_service_active {
                     <td class="nowrap">
-                        <p><% $item._content_type %></p>
                     % if $item.links.document_metadata {
+                     % if ($item._content_type == 'application/zip') {
+                        <div>
+                            <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'zip', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]);"<% } %>>Download ZIP</a></div>
+                     % } else {
                     <div>
                         <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'pdf', download => 0) %>" target="_blank" class="download" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 2]);"<% } %>>View PDF
                         <span class="visuallyhidden"><% include "company/filing_history/transaction_description.html.tx" { item => $item } %> - link opens in a new window <% if ($item.pages) { %> - <% ln('%d page', '%d pages', $item.pages) } %></span></a>
@@ -80,6 +83,7 @@
                         <div>
                             <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'xhtml', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]);"<% } %>>Download iXBRL</a></div>
                         % }
+                    % }
                     % } else if ($item._missing_message != 'available_in_5_days' && !$item._missing_doc) {
                          % if $c.config.feature.missing_image_delivery {
                             <a href="orderable/missing-image-deliveries/<% $item.transaction_id %>" class="normal piwik-event" data-event-id="Request Document">Request Document</a>

--- a/templates/company/filing_history/view_content.html.tx
+++ b/templates/company/filing_history/view_content.html.tx
@@ -70,6 +70,7 @@
                 </td>
                 % if $image_service_active {
                     <td class="nowrap">
+                        <p><% $item._content_type %></p>
                     % if $item.links.document_metadata {
                     <div>
                         <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'pdf', download => 0) %>" target="_blank" class="download" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 2]);"<% } %>>View PDF

--- a/templates/company/transactions/document_download.html.tx
+++ b/templates/company/transactions/document_download.html.tx
@@ -43,6 +43,11 @@
                             <a href="<% $c.url_for('document_download', id => $item._document_id, document_type => 'xhtml') %>">XHTML</a>
                         </li>
                     % }
+                    % if ($metadata.resources['application/zip']) {
+                        <li id="zip">
+                            <a href="<% $c.url_for('document_download', id => $item._document_id, document_type => 'zip') %>">ZIP</a>
+                        </li>
+                    % }
                 </ul>
             %}
 


### PR DESCRIPTION
Add calls to Document API to check Content Type for filing history items which are of type application/zip

UK-144


As discussed, a future minor fix will also be carried out as part of https://companieshouse.atlassian.net/browse/UK-155. This work will involve changing the _get_content_type sub to correctly return an array and for the view_content.html.tx to correctly handle this new logic and display the correct links.