### PR TITLE
Update error page titles to provide detail for screen readers

### DIFF
--- a/lib/ChGovUk/Transaction.pm
+++ b/lib/ChGovUk/Transaction.pm
@@ -281,7 +281,7 @@ sub submit {
                     }
 
                     warn "Failed to update transaction %s: %s", $transaction->transaction_number, $tx->error->{message} [ROUTING];
-                    return $self->controller->render('error', status => $code, error => 'transaction_not_open', check_your_filings => 'true');
+                    return $self->controller->render('error', status => $code, error => 'transaction_not_open', description => "This transaction is no longer open", check_your_filings => 'true');
                 },
             )->execute;
         },
@@ -315,7 +315,7 @@ sub submit {
             }
 
             warn "Failed to update transaction %s: %s", $transaction->transaction_number, $tx->error->{message} [ROUTING];
-            return $self->controller->render('error', status => $code, error => 'transaction_not_open', check_your_filings => 'true');
+            return $self->controller->render('error', status => $code, error => 'transaction_not_open', description => "This transaction is no longer open", check_your_filings => 'true');
         },
     )->execute;
 }

--- a/templates/error.html.tx
+++ b/templates/error.html.tx
@@ -1,4 +1,4 @@
-% cascade base { title => 'Error page' }
+% cascade base { title => $description ~" - Find and update company information - GOV.UK" }
 
 % around content -> {
     <article class="text">


### PR DESCRIPTION
- Update title to use error description and add service name and govuk to the title.
- Add descriptions to errors where it was missing.

Resolves: CHS-2052