### PR TITLE
Remove flag that prevents accessibility statement showing

### DIFF
--- a/templates/base.tx
+++ b/templates/base.tx
@@ -295,13 +295,11 @@
                   Contact us
                 </a>
               </li>
-              % if ! $accessibility_statement_off {
-                <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="/help/accessibility-statement">
-                    Accessibility statement
-                  </a>
-                </li>
-              % }
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="/help/accessibility-statement">
+                  Accessibility statement
+                </a>
+              </li>
               <li class="govuk-footer__inline-list-item">
                 <a class="govuk-footer__link" href="https://developer.companieshouse.gov.uk/" target="_blank">
                   Developers

--- a/templates/company/filing_history/view_certified.html.tx
+++ b/templates/company/filing_history/view_certified.html.tx
@@ -1,4 +1,4 @@
-% cascade base { title => $company.company_name ~" - Filing history (free information from Companies House)", classes => "filing-history", require_js => "transactions/company/filing_history_view", disable_header_search => 1, certified_copies => 1, user_bar => false, insights_bar => false, accessibility_statement_off => true }
+% cascade base { title => $company.company_name ~" - Filing history (free information from Companies House)", classes => "filing-history", require_js => "transactions/company/filing_history_view", disable_header_search => 1, certified_copies => 1, user_bar => false, insights_bar => false }
 %# a widget/block that allows a) "Show form type" to be toggled on/off b) results to be filtered by category
 % block category_console -> {
         <form class="form">


### PR DESCRIPTION
Flag was only used on the certified documents filing history ordering screen. Therefore the flag can now be completely removed as it is now required in certified documents.

Resolves: BI-8844