### PR TITLE
Update error page rendering to display correct titles for all error pages

### DIFF
--- a/errors.yml
+++ b/errors.yml
@@ -45,6 +45,9 @@ errors:
     company_not_found: "Company not found"
     transaction_not_exist: "This transaction does not exist for this company"
     transaction_not_open: "This transaction is no longer open"
+    outside_result_set: "You have requested a page outside of the available result set"
+    search_service_unavailable: "The search service is currently unavailable"
+    page_unavailable: "You have requested a page that is currently unavailable."
 
   ch_gov_uk:
     models:

--- a/lib/ChGovUk/Controllers/Company/Mortgages.pm
+++ b/lib/ChGovUk/Controllers/Company/Mortgages.pm
@@ -32,7 +32,7 @@ sub view {
 
     if (!$self->config->{feature}->{mortgage} && !$self->can_do('/admin/mortgages')) {
         warn "mortgage index feature is not available to non admin users" [MORTGAGES];
-        $self->render('error', error => "invalid_request", description => "You have requested a page that is currently unavailable.", status => 500 );
+        $self->render('error', error => "page_unavailable", description => "You have requested a page that is currently unavailable.", status => 500 );
 
         return ;
     }
@@ -184,7 +184,7 @@ sub view_details {
 
     if (!$self->config->{feature}->{mortgage} && !$self->can_do('/admin/mortgages')) {
         warn "mortgage details feature is not available to non admin users" [MORTGAGE_DETAILS];
-        $self->render('error', error => "invalid_request", description => "You have requested a page that is currently unavailable.", status => 500 );
+        $self->render('error', error => "page_unavailable", description => "You have requested a page that is currently unavailable.", status => 500 );
         return ;
     }
 

--- a/lib/ChGovUk/Controllers/Company/Pscs.pm
+++ b/lib/ChGovUk/Controllers/Company/Pscs.pm
@@ -15,7 +15,7 @@ sub list {
 
     if ($self->config->{feature}->{psc} != 1) {
         warn "PSCs feature flat not set" [PSCs];
-        $self->render('error', error => "invalid_request", description => "You have requested a page that is currently unavailable.", status => 500 );
+        $self->render('error', error => "page_unavailable", description => "You have requested a page that is currently unavailable.", status => 500 );
 
         return;
     }

--- a/lib/ChGovUk/Controllers/Company/Registers/Pscs.pm
+++ b/lib/ChGovUk/Controllers/Company/Registers/Pscs.pm
@@ -15,7 +15,7 @@ sub list {
 
     if ($self->config->{feature}->{psc} != 1) {
         warn "PSCs feature flat not set" [PSCs];
-        $self->render('error', error => "invalid_request", description => "You have requested a page that is currently unavailable.", status => 500 );
+        $self->render('error', error => "page_unavailable", description => "You have requested a page that is currently unavailable.", status => 500 );
 
         return;
     }

--- a/lib/ChGovUk/Controllers/RegisterOfDisqualifications.pm
+++ b/lib/ChGovUk/Controllers/RegisterOfDisqualifications.pm
@@ -70,8 +70,8 @@ sub list {
             error 'Failed to retrieve search results: [%s] [%s]', $error_code, $error_message;
 
             return $error_code == 416
-                ? $self->render('error', error => 'invalid_request', description => 'You have requested a page outside of the available result set', status => 416)
-                : $self->render('error', error => 'internal_error', description => 'The search service is currently unavailable', status => 500);
+                ? $self->render('error', error => 'outside_result_set', description => 'You have requested a page outside of the available result set', status => 416)
+                : $self->render('error', error => 'search_service_unavailable', description => 'The search service is currently unavailable', status => 500);
         },
         error => sub {
             my ($api, $error) = @_;

--- a/lib/ChGovUk/Controllers/Search.pm
+++ b/lib/ChGovUk/Controllers/Search.pm
@@ -100,9 +100,9 @@ sub results {
             my $message = 'Error '.(defined $error_code ? "[$error_code] " : '').'retrieving search results: '.$error_message;
             error "Failure: $message" [Search];
             if ( $error_code eq '416' ){
-                $self->render('error', error => "invalid_request", description => "You have requested a page outside of the available result set", status => 416  ) if $self->accepts('html');
+                $self->render('error', error => "outside_result_set", description => "You have requested a page outside of the available result set", status => 416  ) if $self->accepts('html');
             } else {
-                $self->render('error', error => "internal_error", description => "The search service is currently unavailable", status => 500 ) if $self->accepts('html');
+                $self->render('error', error => "search_service_unavailable", description => "The search service is currently unavailable", status => 500 ) if $self->accepts('html');
             }
         },
 

--- a/lib/ChGovUk/Controllers/Search/CompanyNameAvailability.pm
+++ b/lib/ChGovUk/Controllers/Search/CompanyNameAvailability.pm
@@ -51,7 +51,7 @@ sub company_name_availability {
 
             error 'Failed to retrieve search results: [%s] [%s]', $error_code, $error_message;
 
-            return $self->render('error', error => 'invalid_request', description => 'You have requested a page outside of the available result set', status => 416)
+            return $self->render('error', error => 'outside_result_set', description => 'You have requested a page outside of the available result set', status => 416)
                 if $error_code == 416;
               
             # don't throw to the error page show a message inline 

--- a/lib/ChGovUk/Plugins/Bridges.pm
+++ b/lib/ChGovUk/Plugins/Bridges.pm
@@ -247,7 +247,7 @@ sub _transaction_bridge{
 
                 if ($code == 404) {
                     error "Transaction [%s] does not exist. Continuing.", $self->stash('transaction_number');
-                    return $self->render('error', error => "does_not_exist", description => "This transaction does not exist for this company", status => 404 );
+                    return $self->render('error', error => "transaction_not_exist", description => "This transaction does not exist for this company", status => 404 );
                 }
 
                 error "Failure fetching transaction: [%s] . Error: [%s].", $self->stash('transaction_number'), $tx->error->{message};

--- a/lib/ChGovUk/Transaction.pm
+++ b/lib/ChGovUk/Transaction.pm
@@ -281,7 +281,7 @@ sub submit {
                     }
 
                     warn "Failed to update transaction %s: %s", $transaction->transaction_number, $tx->error->{message} [ROUTING];
-                    return $self->controller->render('error', status => $code, error => 'transaction_not_open', description => "This transaction is no longer open", check_your_filings => 'true');
+                    return $self->controller->render('error', status => $code, error => 'transaction_not_open', check_your_filings => 'true');
                 },
             )->execute;
         },
@@ -315,7 +315,7 @@ sub submit {
             }
 
             warn "Failed to update transaction %s: %s", $transaction->transaction_number, $tx->error->{message} [ROUTING];
-            return $self->controller->render('error', status => $code, error => 'transaction_not_open', description => "This transaction is no longer open", check_your_filings => 'true');
+            return $self->controller->render('error', status => $code, error => 'transaction_not_open', check_your_filings => 'true');
         },
     )->execute;
 }

--- a/templates/error.html.tx
+++ b/templates/error.html.tx
@@ -1,4 +1,4 @@
-% cascade base { title => $description ~" - Find and update company information - GOV.UK" }
+% cascade base { title => $c.config.errors.default[$error] ~" - Find and update company information - GOV.UK" }
 
 % around content -> {
     <article class="text">


### PR DESCRIPTION
Description cannot be used in all error pages and many error types are not defined. This PR adds a error constant for all error types to enable use of the errors constants for page titles.
Resolves: CHS-2052