### PR TITLE
Remove view link for non accounts transactions

### DIFF
--- a/templates/includes/transaction.tx
+++ b/templates/includes/transaction.tx
@@ -76,7 +76,7 @@
                             <td id = "view-submission-<% $~filing.count %>">
 
                             % if $c.can_do('/admin/transaction-lookup') {
-                                % if $filing.value.type != 'registered-office-address' {
+                                % if $filing.value.type == 'accounts' || $filing.value.type == 'abridged' || $filing.value.type == 'smallfull' {
                                   <div id="widget">
                                       <a class="render-accounts-document" href="#"> View </a>
                                       <div id="status-widget" class="widget-footer hidden">
@@ -101,7 +101,7 @@
                             <td id = "submission-status-<% $~filing.count %>"><strong class="status">Processing</strong></td>
                             <td id = "view-submission-<% $~filing.count %>">
                             % if $c.can_do('/admin/transaction-lookup') {
-                              % if $filing.value.type != 'registered-office-address' {
+                              % if $filing.value.type == 'accounts' || $filing.value.type == 'abridged' || $filing.value.type == 'smallfull' {
                                   <div id="widget">
                                     <a class="render-accounts-document" href="#"> View </a>
                                     <div id="status-widget" class="widget-footer hidden">
@@ -147,7 +147,7 @@
                             </td>
                             <td>
                             % if $c.can_do('/admin/transaction-lookup') {
-                              % if $filing.value.type != 'registered-office-address' {
+                              % if $filing.value.type == 'accounts' || $filing.value.type == 'abridged' || $filing.value.type == 'smallfull' {
                                   <div id="widget">
                                     <a class="render-accounts-document" href="#"> View </a>
                                     <div id="status-widget" class="widget-footer hidden">

--- a/templates/includes/transactions.tx
+++ b/templates/includes/transactions.tx
@@ -100,7 +100,7 @@
                                         <td id = "transaction-<% $~transaction.count %>-view-submission-<% $~filing.count %>">
 
                                         % if $c.can_do('/admin/transaction-lookup') {
-                                          % if $filing.value.type != 'registered-office-address' {
+                                          % if $filing.value.type == 'accounts' || $filing.value.type == 'abridged' || $filing.value.type == 'smallfull' {
                                               <div id="widget">
                                                 <a class="render-accounts-document" href="#"> View </a>
                                                 <div id="status-widget" class="widget-footer hidden">
@@ -125,7 +125,7 @@
                                         <td id = "transaction-<% $~transaction.count %>-submission-status-<% $~filing.count %>"><strong class="status">Processing</strong></td>
 <td id = "transaction-<% $~transaction.count %>-view-submission-<% $~filing.count %>">
                                         % if $c.can_do('/admin/transaction-lookup') {
-                                          % if $filing.value.type != 'registered-office-address' {
+                                          % if $filing.value.type == 'accounts' || $filing.value.type == 'abridged' || $filing.value.type == 'smallfull' {
                                               <div id="widget">
                                                 <a class="render-accounts-document" href="#"> View </a>
                                                 <div id="status-widget" class="widget-footer hidden">
@@ -171,7 +171,7 @@
                                         </td>
                                         <td>
                                         % if $c.can_do('/admin/transaction-lookup') {
-                                          % if $filing.value.type != 'registered-office-address' {
+                                          % if $filing.value.type == 'accounts' || $filing.value.type == 'abridged' || $filing.value.type == 'smallfull' {
                                               <div id="widget">
                                                 <a class="render-accounts-document" href="#"> View </a>
                                                 <div id="status-widget" class="widget-footer hidden">


### PR DESCRIPTION
Do not display view link on admin screen for non account transactions

Filing types for account transactions taken from: https://github.com/companieshouse/chips-filing-consumer/blob/fe2fd358776d57159cc03a54bc40fe1e9a81b12b/src/main/java/uk/gov/ch/services/documentinput/FilingTypes.java

Resolves: https://companieshouse.atlassian.net/browse/NCS-667