### PR TITLE
Prevent pre95 cert docs to be orderable

### DIFF
--- a/templates/company/filing_history/view_content_certified.html.tx
+++ b/templates/company/filing_history/view_content_certified.html.tx
@@ -66,26 +66,30 @@
                     % }
                 </td>
                 <td class="nowrap">
-                % if (!($item.type == 'PRE95') || !($item.type == 'PRE95M')) && !($item._missing_message == 'unavailable') && !($item._missing_message == 'available_in_5_days') || $item.links.document_metadata  {
-                    % if $item.type == "NEWINC" {
-                        £30
-                    % } else {
-                        £15
+                % if ($item.type != 'PRE95') || !($item.type != 'PRE95M') {
+                    % if !($item._missing_message == 'unavailable') && !($item._missing_message == 'available_in_5_days') || $item.links.document_metadata  {
+                        % if $item.type == "NEWINC" {
+                            £30
+                        % } else {
+                            £15 
+                        % }
                     % }
-                % }
-                </td>
-                <td> 
-                % if (!($item.type == 'PRE95') || !($item.type == 'PRE95M')) && !($item._missing_message == 'unavailable') && !($item._missing_message == 'available_in_5_days') || $item.links.document_metadata  {
-                    <form action="<%'/company/' ~ $company.company_number ~ '/certified-documents' %>" method="post">
-                        <input type="hidden" id="<% $item.transaction_id %>" name="transaction" value="<% $item.transaction_id %>">
-                        <input type="submit" class="select-document-button-link" id="add-document-to-order-<% $item.transaction_id%>"
-                            value="<% l('Select document') %>"
-                            % if $c.config.piwik.embed {
-                                    onclick="javascript:_paq.push(['trackEvent', 'AddDocumentToOrder']);"
-                            % }
-                            >
-                        </input>
-                    </form>
+                    </td>
+                    <td> 
+                    % if !($item._missing_message == 'unavailable') && !($item._missing_message == 'available_in_5_days') || $item.links.document_metadata  {
+                        <form action="<%'/company/' ~ $company.company_number ~ '/certified-documents' %>" method="post">
+                            <input type="hidden" id="<% $item.transaction_id %>" name="transaction" value="<% $item.transaction_id %>">
+                            <input type="submit" class="select-document-button-link" id="add-document-to-order-<% $item.transaction_id%>"
+                                value="<% l('Select document') %>"
+                                % if $c.config.piwik.embed {
+                                        onclick="javascript:_paq.push(['trackEvent', 'AddDocumentToOrder']);"
+                                % }
+                                >
+                            </input>
+                        </form>
+                    % }
+                % } else {
+                    <td></td>
                 % }
                 </td>
             </tr>


### PR DESCRIPTION
update logic for initial check of pre95 and pre95m types 
add a td to complete the empty column styling

Resolves: BI-10160