### PR TITLE
BI-10372 - Add govuk-link to download ixbrl link

### DIFF
--- a/templates/company/filing_history/view_content.html.tx
+++ b/templates/company/filing_history/view_content.html.tx
@@ -82,7 +82,7 @@
                         <% if ($item.pages) { %> (<% ln('%d page', '%d pages', $item.pages) %>)<% } %></div>
                         % if !$item.paper_filed && $item.type == 'AA' && $item._xhtml_is_available {
                         <div>
-                            <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'xhtml', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]);"<% } %>>Download iXBRL</a></div>
+                            <a class="govuk-link" href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'xhtml', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]);"<% } %>>Download iXBRL</a></div>
                         % }
                     % }
                     % } else if ($item._missing_message != 'available_in_5_days' && !$item._missing_doc) {


### PR DESCRIPTION
Add additional `govuk-link` class to the download ixbrl link so that all links present on the filing history have the correct link styling and behaviour.
Resolves: BI-10372