### PR TITLE
Fix issue with Revised Accounts

### DIFF
--- a/templates/company/filing_history/view_content.html.tx
+++ b/templates/company/filing_history/view_content.html.tx
@@ -80,7 +80,7 @@
                         <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'pdf', download => 0) %>" target="_blank" class="download govuk-link" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 2]);"<% } %>>View PDF
                         <span class="govuk-visually-hidden"><% include "company/filing_history/transaction_description.html.tx" { item => $item } %> - link opens in a new window <% if ($item.pages) { %> - <% ln('%d page', '%d pages', $item.pages) } %></span></a>
                         <% if ($item.pages) { %> (<% ln('%d page', '%d pages', $item.pages) %>)<% } %></div>
-                        % if !$item.paper_filed && $item.type == 'AA' && $item._xhtml_is_available {
+                        % if !$item.paper_filed && ($item.type == 'AA' || $item.type == 'AAMD')  && $item._xhtml_is_available {
                         <div>
                             <a class="govuk-link" href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'xhtml', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]);"<% } %>>Download iXBRL</a></div>
                         % }


### PR DESCRIPTION
Currently there is a bug in live where ixbrl download link does not appear
for revised/amended accounts. Fix is to add `AAMD` in the check to make sure
revised accounts are also added to display the download link.

Resolves: BI-10339