### PR TITLE
BI-10372 - Enable download ixbrl link to update colour when clicked

### DIFF
--- a/templates/base.tx
+++ b/templates/base.tx
@@ -48,6 +48,7 @@
     <script src='//<% $cdn_url %>/javascripts/app/accounts-pdf.js'></script>
     <script src='//<% $cdn_url %>/javascripts/lib/details-polyfill.js'></script>
     <script src='//<% $cdn_url %>/javascripts/app/generate-document.js'></script>
+    <script src='//<% $cdn_url %>/javascripts/app/download-ixbrl-link.js'></script>
     <script src='//<% $cdn_url %>/javascripts/vendor/jquery-1.12.4.min.js'></script>
     <script>
     require(['//<% $cdn_url %>/javascripts/require-global-config.js'], function () {

--- a/templates/company/filing_history/view_content.html.tx
+++ b/templates/company/filing_history/view_content.html.tx
@@ -82,7 +82,7 @@
                         <% if ($item.pages) { %> (<% ln('%d page', '%d pages', $item.pages) %>)<% } %></div>
                         % if !$item.paper_filed && ($item.type == 'AA' || $item.type == 'AAMD')  && $item._xhtml_is_available {
                         <div>
-                            <a class="govuk-link" href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'xhtml', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]);"<% } %>>Download iXBRL</a></div>
+                            <a class="govuk-link" href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'xhtml', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]); updateLinkColour(this);"<% } %>>Download iXBRL</a></div>
                         % }
                     % }
                     % } else if ($item._missing_message != 'available_in_5_days' && !$item._missing_doc) {


### PR DESCRIPTION
The `Download IXBRL` link does not trigger the visited attribute as it never leaves the page. A work around for this is to update the colour of the link to replicate the behaviour of govuk's visited styles.
Resolves: BI-10372