### PR TITLE
BI-10372 - Enable link to use visited style on non compatible browsers

### DIFF
--- a/templates/base.tx
+++ b/templates/base.tx
@@ -48,7 +48,7 @@
     <script src='//<% $cdn_url %>/javascripts/app/accounts-pdf.js'></script>
     <script src='//<% $cdn_url %>/javascripts/lib/details-polyfill.js'></script>
     <script src='//<% $cdn_url %>/javascripts/app/generate-document.js'></script>
-    <script src='//<% $cdn_url %>/javascripts/app/download-ixbrl-link.js'></script>
+    <script src='//<% $cdn_url %>/javascripts/app/update-filing-history-link.js'></script>
     <script src='//<% $cdn_url %>/javascripts/vendor/jquery-1.12.4.min.js'></script>
     <script>
     require(['//<% $cdn_url %>/javascripts/require-global-config.js'], function () {

--- a/templates/company/filing_history/view_content.html.tx
+++ b/templates/company/filing_history/view_content.html.tx
@@ -77,17 +77,17 @@
                             <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'zip', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]);"<% } %>>Download ZIP</a></div>
                      % } else {
                     <div>
-                        <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'pdf', download => 0) %>" target="_blank" class="download govuk-link" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 2]);"<% } %>>View PDF
+                        <a href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'pdf', download => 0) %>" target="_blank" class="download link-updater-js govuk-link" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 2]);"<% } %>>View PDF
                         <span class="govuk-visually-hidden"><% include "company/filing_history/transaction_description.html.tx" { item => $item } %> - link opens in a new window <% if ($item.pages) { %> - <% ln('%d page', '%d pages', $item.pages) } %></span></a>
                         <% if ($item.pages) { %> (<% ln('%d page', '%d pages', $item.pages) %>)<% } %></div>
                         % if !$item.paper_filed && ($item.type == 'AA' || $item.type == 'AAMD')  && $item._xhtml_is_available {
                         <div>
-                            <a class="govuk-link" href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'xhtml', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]); updateLinkColour(this);"<% } %>>Download iXBRL</a></div>
+                            <a class="link-updater-js govuk-link" href="<% $c.url_for('filing_history_document', filing_history_id => $item.transaction_id).query(format => 'xhtml', download => 1) %>" <% if $c.config.piwik.embed { %> onclick="javascript:_paq.push(['trackGoal', 3]);"<% } %>>Download iXBRL</a></div>
                         % }
                     % }
                     % } else if ($item._missing_message != 'available_in_5_days' && !$item._missing_doc) {
                          % if $c.config.feature.missing_image_delivery {
-                            <a href="orderable/missing-image-deliveries/<% $item.transaction_id %>" class="normal piwik-event govuk-link" data-event-id="Request Document">Request Document</a>
+                            <a href="orderable/missing-image-deliveries/<% $item.transaction_id %>" class="normal piwik-event link-updater-js govuk-link" data-event-id="Request Document">Request Document</a>
                          % }
                     % }
                     </td>


### PR DESCRIPTION
A number of mobile browsers are not compatible with the visited styles provided by gov-uk. For consistency this enables the links to use the visited styles.
Resolves: BI-10372