### PR TITLE
ROE-177 - Include names in managing officer contact details

### DIFF
--- a/lib/ChGovUk/Plugins/AddressHelper.pm
+++ b/lib/ChGovUk/Plugins/AddressHelper.pm
@@ -62,6 +62,31 @@ sub as_string {
         $address_as_string
     ) if $opts->{include_care_of};
 
+    if ($opts->{include_names}) {
+        my $forename = "";
+        my $other_forenames = "";
+        my $surname = "";
+
+        if ($address->{forename}) {
+            $forename = $address->{forename};
+        }
+
+        if ($address->{other_forenames}) {
+            $other_forenames = $address->{other_forenames};
+        }
+
+        if ($address->{surname}) {
+            $surname = $address->{surname};
+        }
+
+        my $full_name = join ' ', $forename, $other_forenames, $surname;
+
+        $address_as_string = join ', ', grep { $_ && length $_ } (
+            $full_name,
+            $address_as_string
+        ) if $full_name;
+    }
+
     $address_as_string =~ s/,,/,/g if $opts->{suppress_double_commas};
 
     return $address_as_string;

--- a/t/unit/ChGovUk/Plugins/AddressHelper.t
+++ b/t/unit/ChGovUk/Plugins/AddressHelper.t
@@ -28,6 +28,9 @@ my $api_hash = {
     postal_code      => 'SA1 3SN',
     po_box           => '789',
     care_of          => 'The Janitor',
+    forename         => 'Cliff',
+    other_forenames  => 'John',
+    surname          => 'Richard'
 };
 
 test_method_register();
@@ -82,6 +85,18 @@ sub test_helper_address_as_string_with_po_box {
         is(
             $app->controller->address_as_string($api_hash, {include_po_box => 1}),
             'PO Box Tottenham Hotspur, Civic Centre, Oystermouth Road, The Seafront, Swansea, Glamorgan, Wales, SA1 3SN'
+        );
+    };
+}
+
+# ------------------------------------------------------------------------------
+
+sub test_helper_address_as_string_with_names {
+    subtest "Test method - as_string with optional name fields" => sub {
+        is(
+            $app->controller->address_as_string($api_hash, {include_names => 1} ),
+            'Cliff John Richard, The Janitor, Civic Centre, Oystermouth Road, The Seafront, Swansea, Glamorgan, Wales, SA1 3SN',
+            'Get formatted address as string with care of field'
         );
     };
 }

--- a/templates/company/officers/list.html.tx
+++ b/templates/company/officers/list.html.tx
@@ -247,7 +247,7 @@
                     <dl>
                         <dt><% l('Contact for corporate managing officer') %></dt>
                         <dd id="officer-contact-details-<% $~officer.count %>" class="data">
-                            % $c.address_as_string( $officer.contact_details, { include_care_of => 1, title_case_care_of => 1, include_po_box => 1 } )
+                            % $c.address_as_string( $officer.contact_details, { include_care_of => 1, title_case_care_of => 1, include_po_box => 1, include_names => 1 } )
                         </dd>
                     </dl>
                 % }


### PR DESCRIPTION
Ensure that names present in contact details for managing officers are displayed.

Resolves: ROE-177