### PR TITLE
roe removed company status removed active tag for bo

### DIFF
--- a/templates/company/pscs/list.html.tx
+++ b/templates/company/pscs/list.html.tx
@@ -119,7 +119,7 @@
                         </span>
                         % if $psc.ceased_on || $psc.ceased {
                             <span id="psc-status-tag-<% $~psc.count %>" class="status-tag ceased-tag font-xsmall">Ceased</span>
-                        % } else if $company.company_status != 'dissolved' && $company.company_status != 'converted-closed'{
+                        % } else if $company.company_status != 'dissolved' && $company.company_status != 'converted-closed' && $company.company_status != 'removed'{
                             <span id="psc-status-tag-<% $~psc.count %>" class="status-tag font-xsmall">Active</span>
                         % }
                     </h2>


### PR DESCRIPTION
add logic to not output the active tag for a beneficial owner where the roe company status is removed

Resolves: GCI-2116