### PR TITLE
allow roe companies to output bo data when name is missing

### DIFF
--- a/templates/company/pscs/list.html.tx
+++ b/templates/company/pscs/list.html.tx
@@ -101,7 +101,7 @@
     <div class="appointments-list">
         % for $pscs.items -> $psc {
             
-            % if $psc.name || $psc.description{ 
+            % if $psc.name || $psc.description || $company.type == 'registered-overseas-entity'{
             
             <div class="appointment-<% $~psc.count %>">
                 % if $~psc.is_first {


### PR DESCRIPTION
allow roe companies to output bo data when name is missing

Resolves: ROE-632