### PR TITLE
GCI-2156 Append certified documents to basket if user enrolled

### DIFF
--- a/appconfig.yml
+++ b/appconfig.yml
@@ -144,4 +144,5 @@ show_feedback_page: <SHOW_FEEDBACK_PAGE>
 
 allowed_return_to_hosts: <ALLOWED_RETURN_TO_HOSTS>
 
-basket_api_url: <BASKET_API_URL>
+basket_api_url: "<ERIC_LOCAL_URL>/basket"
+append_item_to_basket_url: "<ERIC_LOCAL_URL>/basket/items/append"

--- a/appconfig.yml
+++ b/appconfig.yml
@@ -143,3 +143,5 @@ show_covid19_message: <SHOW_COVID19_MESSAGE>
 show_feedback_page: <SHOW_FEEDBACK_PAGE>
 
 allowed_return_to_hosts: <ALLOWED_RETURN_TO_HOSTS>
+
+basket_api_url: <BASKET_API_URL>

--- a/lib/ChGovUk/Controllers/Company/BasketClient.pm
+++ b/lib/ChGovUk/Controllers/Company/BasketClient.pm
@@ -1,0 +1,31 @@
+package ChGovUk::Controllers::Company::BasketClient;
+
+use Moose;
+
+has 'user_agent' => (is => 'ro', isa => 'Object');
+has 'access_token' => (is => 'ro', isa => 'Str');
+has 'basket_url' => (is => 'ro', isa => 'Str');
+
+sub get_basket {
+    my $self = shift;
+    my $tx = $self->user_agent->get($self->basket_url => { Authorization => "Bearer ".$self->access_token });
+
+    if ($tx->success) {
+        my $body = $tx->success->json;
+        my $hasDeliverableItems;
+
+        for my $item (@{$body->{items} || []}) {
+            if ($item->{kind} eq 'item#certificate' || $item->{kind} eq 'item#certified-copy') {
+                $hasDeliverableItems = 1;
+                last;
+            }
+        }
+
+        return { enrolled => $body->{enrolled}, hasDeliverableItems => $hasDeliverableItems }
+    }
+
+    return undef;
+}
+
+1;
+

--- a/lib/ChGovUk/Controllers/Company/BasketClient.pm
+++ b/lib/ChGovUk/Controllers/Company/BasketClient.pm
@@ -12,7 +12,7 @@ sub get_basket {
 
     if ($tx->success) {
         my $body = $tx->success->json;
-        my $hasDeliverableItems;
+        my $hasDeliverableItems = 0;
 
         for my $item (@{$body->{items} || []}) {
             if ($item->{kind} eq 'item#certificate' || $item->{kind} eq 'item#certified-copy') {
@@ -21,7 +21,7 @@ sub get_basket {
             }
         }
 
-        return { enrolled => $body->{enrolled}, hasDeliverableItems => $hasDeliverableItems }
+        return { enrolled => ${$body->{enrolled} || \0}, hasDeliverableItems => $hasDeliverableItems };
     }
 
     return undef;

--- a/lib/ChGovUk/Controllers/Company/BasketClient.pm
+++ b/lib/ChGovUk/Controllers/Company/BasketClient.pm
@@ -5,6 +5,7 @@ use Moose;
 has 'user_agent' => (is => 'ro', isa => 'Object');
 has 'access_token' => (is => 'ro', isa => 'Str');
 has 'basket_url' => (is => 'ro', isa => 'Str');
+has 'append_item_url' => (is => 'ro', isa => 'Str');
 
 sub get_basket {
     my $self = shift;
@@ -25,6 +26,18 @@ sub get_basket {
     }
 
     return undef;
+}
+
+sub append_item_to_basket {
+    my ($self, $request) = @_;
+
+    my $tx = $self->user_agent->post($self->append_item_url => { Authorization => 'Bearer ' . $self->access_token } => json => $request);
+
+    if ($tx->success) {
+        return { status => 0 };
+    } else {
+        return { status => 1 };
+    }
 }
 
 1;

--- a/lib/ChGovUk/Controllers/Company/CertifiedDocuments.pm
+++ b/lib/ChGovUk/Controllers/Company/CertifiedDocuments.pm
@@ -202,7 +202,23 @@ sub post {
             my ($api, $tx) = @_;
             my $certifiedCopy = $tx->success->json;
             my $certifiedCopyId = $certifiedCopy->{'id'};
-            my $location = "/orderable/certified-copies/${certifiedCopyId}/delivery-details";
+            my $basket_client = ChGovUk::Controllers::Company::BasketClient->new({
+                user_agent   => $self->ua,
+                access_token => $self->access_token->{access_token},
+                basket_url   => $self->config->{basket_api_url}
+            });
+
+            my $basket = $basket_client->get_basket;
+            my $location;
+            if ($basket->{enrolled}) {
+                if ($basket->{hasDeliverableItems}) {
+                    $location = "/basket";
+                } else {
+                    $location = "/delivery-details";
+                }
+            } else {
+                $location = "/orderable/certified-copies/${certifiedCopyId}/delivery-details";
+            }
             $self->redirect_to($location);
         },
         error   => sub {

--- a/lib/ChGovUk/Controllers/Company/CertifiedDocuments.pm
+++ b/lib/ChGovUk/Controllers/Company/CertifiedDocuments.pm
@@ -11,6 +11,7 @@ use POSIX qw/ceil/;
 use JSON::XS;
 use ChGovUk::Plugins::FilterHelper;
 use DateTime;
+use ChGovUk::Controllers::Company::BasketClient;
 
 # all categories (that can be filtered by)
 use constant AVAILABLE_CATEGORIES => {
@@ -134,6 +135,14 @@ sub view {
             trace "filing history total_count %d entries per page %d",
                 $pager->total_entries, $pager->entries_per_page() [FILING_HISTORY];
 
+            my $basket_client = ChGovUk::Controllers::Company::BasketClient->new({
+                user_agent   => $self->ua,
+                access_token => $self->access_token->{access_token},
+                basket_url   => $self->config->{basket_api_url}
+            });
+
+            my $basket = $basket_client->get_basket;
+
             $self->stash(current_page_number     => $pager->current_page);
             $self->stash(page_set                => $pager->pages_in_set());
             $self->stash(next_page               => $pager->next_page());
@@ -146,6 +155,7 @@ sub view {
             $self->stash(categories              => $categories);
             $self->stash(selected_category_count => $selected_category_count);
             $self->stash(split_category_at       => ceil(@$categories / 2));
+            $self->stash(enrolled                => $basket->{enrolled});
 
             if ($self->req->is_xhr) {
                 $self->render(template => 'company/filing_history/view_content_certified');

--- a/t/unit/ChGovUk/Controllers/Company/BasketClient.t
+++ b/t/unit/ChGovUk/Controllers/Company/BasketClient.t
@@ -1,0 +1,90 @@
+use strict;
+use warnings;
+
+package MockResponse;
+
+use Moose;
+
+has 'expectedBody' => (is => 'rw', isa => 'Any');
+
+sub json {
+    my $self = shift;
+
+    return $self->expectedBody;
+}
+
+package MockTransaction;
+
+use Moose;
+
+has 'mockResponse' => (is => 'rw', isa => 'Any');
+
+sub success {
+    my $self = shift;
+
+    return $self->mockResponse;
+}
+
+package MockUserAgent;
+
+use Moose;
+
+has 'mockTransaction' => (is => 'ro', isa => 'Object');
+
+sub get {
+    my $self = shift;
+
+    return $self->mockTransaction;
+}
+
+package main;
+
+use Test::More;
+
+my $class = "ChGovUk::Controllers::Company::BasketClient";
+my $basket_client;
+my $mockResponse = MockResponse->new;
+my $mockTransaction = MockTransaction->new({
+    mockResponse => $mockResponse
+});
+
+subtest "Can use the basket client as a dependency" => sub {
+    use_ok $class, "Use a BasketClient as a dependency";
+};
+
+subtest "Can instantiate a basket client" => sub {
+    $basket_client = new_ok $class => [{user_agent => MockUserAgent->new({mockTransaction => $mockTransaction}), access_token => "access_token", basket_url => "basket_url"}];
+};
+
+subtest "Can use a basket client to fetch a user's basket" => sub {
+    can_ok $basket_client, 'get_basket';
+};
+
+subtest "Get basket" => sub {
+    plan tests => 3;
+    subtest "Fetch and map user's basket where user is enrolled and basket has deliverable items" => sub {
+        $mockResponse->expectedBody({
+            items    => [ { kind => 'item#certified-copy' } ],
+            enrolled => \1
+        });
+        my $actual = $basket_client->get_basket;
+        is_deeply $actual, { enrolled => 1, hasDeliverableItems => 1 }, "Return value should match expected value";
+    };
+
+    subtest "Fetch and map user's basket where user is disenrolled and basket has no deliverable items" => sub {
+        $mockResponse->expectedBody({
+            items    => [ { kind => 'item#missing-image-delivery' } ],
+            enrolled => \0
+        });
+        my $actual = $basket_client->get_basket;
+        is_deeply $actual, { enrolled => 0, hasDeliverableItems => 0 }, "Return value should match expected value";
+    };
+
+    subtest "Return undef if an error occurs when fetching user's basket" => sub {
+        $mockTransaction->mockResponse(undef);
+        my $actual = $basket_client->get_basket;
+        is $actual, undef, "Return value should be undefined";
+    };
+};
+
+done_testing;

--- a/templates/company/filing_history/view_content_certified.html.tx
+++ b/templates/company/filing_history/view_content_certified.html.tx
@@ -63,12 +63,12 @@
                     % }
                 </td>
                 % if ($item.type != 'PRE95') && ($item.type != 'PRE95M') {
-                    <td> 
+                    <td>
                     % if !($item._missing_message == 'unavailable') && !($item._missing_message == 'available_in_5_days') || $item.links.document_metadata  {
                         <form action="<%'/company/' ~ $company.company_number ~ '/certified-documents' %>" method="post">
                             <input type="hidden" id="<% $item.transaction_id %>" name="transaction" value="<% $item.transaction_id %>">
                             <input type="submit" class="select-document-button-link" id="add-document-to-order-<% $item.transaction_id%>"
-                                value="<% l('Select document') %>"
+                                value="<% if($enrolled) { l('Add to basket') } else { l('Select document') } %>"
                                 % if $c.config.piwik.embed {
                                         onclick="javascript:_paq.push(['trackEvent', 'AddDocumentToOrder']);"
                                 % }


### PR DESCRIPTION
* Link text on certified document selection page changed to "Add to basket" if user enrolled.
* POST new item to appendItemToBasket endpoint.
* Enrolled user redirected to /basket if deliverable items already in basket.
* Enrolled user redirected to /delivery-details if no deliverable items already in basket.

Resolves:
[GCI-2156](https://companieshouse.atlassian.net/browse/GCI-2156)