### PR TITLE
Fix incorrect redirect URL in cert doc handler

### DIFF
--- a/lib/ChGovUk/Controllers/Company/CertifiedDocuments.pm
+++ b/lib/ChGovUk/Controllers/Company/CertifiedDocuments.pm
@@ -235,7 +235,7 @@ sub post {
                 if ($basket->{hasDeliverableItems}) {
                     $location = "/basket";
                 } else {
-                    $location = "/delivery-options";
+                    $location = "/orderable/certified-copies/${certifiedCopyId}/delivery-options";
                 }
             } else {
                 $location = "/orderable/certified-copies/${certifiedCopyId}/delivery-options";


### PR DESCRIPTION
* ChGovUk::Controllers::Company::CertifiedDocuments should redirect user
  agent to /orderable/certified-copies/{id}/delivery-options if user is
  enrolled or not.