### PR TITLE
add govuk hidden css class to empty table header

### DIFF
--- a/templates/includes/transactions.tx
+++ b/templates/includes/transactions.tx
@@ -82,7 +82,7 @@
                                 % if $c.can_do('/admin/transaction-lookup') {
                                     <th class="actions">Actions</th>
                                 % } else {
-                                    <th></th>
+                                    <th class="govuk-visually-hidden"></th>
                                 % }
                             </tr>
                         </thead>


### PR DESCRIPTION
add govuk hidden css class to empty table header

Resolves: GCI-2231