### PR TITLE
BI-11898: Company name availability basket link

### DIFF
--- a/lib/ChGovUk/Controllers/Search/CompanyNameAvailability.pm
+++ b/lib/ChGovUk/Controllers/Search/CompanyNameAvailability.pm
@@ -124,6 +124,13 @@ sub get_basket() {
                 debug "User not authenticated; not displaying basket link", [HOMEPAGE];
                 # TODO Or render exception?
                 $self->stash_basket_link(0, undef);
+                if ($company_name) {
+                    debug "not_authorised: Calling perform_search()", [HOMEPAGE];
+                    $self->perform_search($company_name);
+                } else {
+                    debug "not_authorised: Rendering page", [HOMEPAGE];
+                    return $self->render(template => "company/company_name_availability/form");
+                }
             },
             failure        => sub {
                 my ($api, $tx) = @_;
@@ -143,13 +150,20 @@ sub get_basket() {
     } else {
         debug "User not signed in; not displaying basket link", [HOMEPAGE];
         $self->stash_basket_link(0, undef);
+        if ($company_name) {
+            debug "Not signed in: Calling perform_search()", [HOMEPAGE];
+            $self->perform_search($company_name);
+        } else {
+            debug "Not signed in: Rendering page", [HOMEPAGE];
+            return $self->render(template => "company/company_name_availability/form");
+        }
     }
 }
 
 sub stash_basket_link {
     my ($self, $basket_items, $show_basket_link) = @_;
 
-    debug "Stashing basket_items = %s, show_basket_link = %s", $basket_items, $show_basket_link [HOMEPAGE];
+    debug "Stashing basket_items = %s, show_basket_link = %s", $basket_items, Dumper($show_basket_link) [HOMEPAGE];
     $self->stash(
         basket_items     => $basket_items,
         show_basket_link => $show_basket_link

--- a/lib/ChGovUk/Controllers/Search/CompanyNameAvailability.pm
+++ b/lib/ChGovUk/Controllers/Search/CompanyNameAvailability.pm
@@ -141,7 +141,12 @@ sub get_basket() {
                 $self->stash_basket_link(0, undef);
                 my $message = "get basket failure";
                 debug "get basket failure, stash = %s", Dumper($self->stash), [HOMEPAGE];
-                return $self->render_exception($message);
+                # return $self->render_exception($message);
+                $self->render(
+                    'error',
+                    error => "search_service_unavailable",
+                    description => "The search service is currently unavailable",
+                    status => 500 );
             },
             error          => sub {
                 my ($api, $tx) = @_;

--- a/lib/ChGovUk/Controllers/Search/CompanyNameAvailability.pm
+++ b/lib/ChGovUk/Controllers/Search/CompanyNameAvailability.pm
@@ -82,7 +82,6 @@ sub perform_search() {
         error => sub {
             my ($api, $error) = @_;
 
-            # TODO Replace render_exception() with agreed error page if possible.
             my $message = "Error retrieving search results: $error";
             error '%s', $message;
 
@@ -137,22 +136,15 @@ sub get_basket() {
                 my ($api, $tx) = @_;
                 debug "failure", [HOMEPAGE];
                 debug "Error returned by getBasketLinks endpoint; not displaying basket link", [HOMEPAGE];
-                # TODO Replace render_exception() with agreed error page if appropriate here and possible.
                 $self->stash_basket_link(0, undef);
                 my $message = "get basket failure";
                 debug "get basket failure, stash = %s", Dumper($self->stash), [HOMEPAGE];
-                # return $self->render_exception($message);
-                $self->render(
-                    'error',
-                    error => "search_service_unavailable",
-                    description => "The search service is currently unavailable",
-                    status => 500 );
+                return $self->render_exception($message);
             },
             error          => sub {
                 my ($api, $tx) = @_;
                 debug "error", [HOMEPAGE];
                 debug "Error returned by getBasketLinks endpoint; not displaying basket link", [HOMEPAGE];
-                # TODO Replace render_exception() with agreed error page if possible.
                 $self->stash_basket_link(0, undef);
                 my $message = "get basket error";
                 debug "get basket error, stash = %s", Dumper($self->stash), [HOMEPAGE];

--- a/lib/ChGovUk/Controllers/Search/CompanyNameAvailability.pm
+++ b/lib/ChGovUk/Controllers/Search/CompanyNameAvailability.pm
@@ -74,17 +74,19 @@ sub perform_search() {
             # don't throw to the error page show a message inline
             $self->stash(query => $company_name, show_error => 1);
 
-            debug "search failure , stash = %s", Dumper($self->stash), [HOMEPAGE];
+            # TODO Use agreed error page if really appropriate here?
+            debug "search failure, stash = %s", Dumper($self->stash), [HOMEPAGE];
             return $self->render(template => "company/company_name_availability/form");
 
         },
         error => sub {
             my ($api, $error) = @_;
 
+            # TODO Replace render_exception() with agreed error page if possible.
             my $message = "Error retrieving search results: $error";
             error '%s', $message;
 
-            debug "search error , stash = %s", Dumper($self->stash), [HOMEPAGE];
+            debug "search error, stash = %s", Dumper($self->stash), [HOMEPAGE];
             return $self->render_exception($message);
         },
     )->execute;
@@ -122,7 +124,6 @@ sub get_basket() {
                 my ($api, $tx) = @_;
                 debug "not_authorised", [HOMEPAGE];
                 debug "User not authenticated; not displaying basket link", [HOMEPAGE];
-                # TODO Or render exception?
                 $self->stash_basket_link(0, undef);
                 if ($company_name) {
                     debug "not_authorised: Calling perform_search()", [HOMEPAGE];
@@ -136,15 +137,21 @@ sub get_basket() {
                 my ($api, $tx) = @_;
                 debug "failure", [HOMEPAGE];
                 debug "Error returned by getBasketLinks endpoint; not displaying basket link", [HOMEPAGE];
-                # TODO Or render exception?
+                # TODO Replace render_exception() with agreed error page if appropriate here and possible.
                 $self->stash_basket_link(0, undef);
+                my $message = "get basket failure";
+                debug "get basket failure, stash = %s", Dumper($self->stash), [HOMEPAGE];
+                return $self->render_exception($message);
             },
             error          => sub {
                 my ($api, $tx) = @_;
                 debug "error", [HOMEPAGE];
                 debug "Error returned by getBasketLinks endpoint; not displaying basket link", [HOMEPAGE];
-                # TODO Or render exception?
+                # TODO Replace render_exception() with agreed error page if possible.
                 $self->stash_basket_link(0, undef);
+                my $message = "get basket error";
+                debug "get basket error, stash = %s", Dumper($self->stash), [HOMEPAGE];
+                return $self->render_exception($message);
             }
         )->execute;
     } else {

--- a/templates/base.tx
+++ b/templates/base.tx
@@ -210,7 +210,6 @@
                           % if !$c.config.disable_follow {
                               <li><a class="govuk-link" id="following" href="<% $c.config.monitor.gui_url %>">Companies you follow</a></li>
                           % }
-                         [$show_basket_link = <% $show_basket_link %>]
                           % if $show_basket_link {
                               <li><a class="govuk-link" id="basket" href="<% $c.config.basket_web_url %>">Basket (<%= $basket_items %>)</a></li>
                           % }

--- a/templates/base.tx
+++ b/templates/base.tx
@@ -210,6 +210,7 @@
                           % if !$c.config.disable_follow {
                               <li><a class="govuk-link" id="following" href="<% $c.config.monitor.gui_url %>">Companies you follow</a></li>
                           % }
+                         [$show_basket_link = <% $show_basket_link %>]
                           % if $show_basket_link {
                               <li><a class="govuk-link" id="basket" href="<% $c.config.basket_web_url %>">Basket (<%= $basket_items %>)</a></li>
                           % }

--- a/templates/exception.production.html.tx
+++ b/templates/exception.production.html.tx
@@ -8,7 +8,11 @@
     </header>
     <article class="text">
             <p>Try again in a few moments.</p>
-            <p>If this problem continues email <a href="mailto:enquiries@companieshouse.gov.uk<% if $exception_id { %>?subject=CHS website exception <% $exception_id %><% } %>">enquiries@companieshouse.gov.uk</a>.</p>
+            <p class="govuk-body">
+                If the problem persists
+                <a class="govuk-link"
+                   href="https://www.gov.uk/government/organisations/companies-house#org-contacts">contact us</a>.
+            </p>
     </article>
 </div>
 % }


### PR DESCRIPTION
* Duplicate implementation from the home page to this page.
* Change implementation to chain fetching of search results after successful fetching of basket link info.
* Use built-in error page in case of issue accessing basket info.
* Tweak error page to include contact us link rather than request to email us. 
* Confirm no automated tests broken by changes.