### PR TITLE
BI-11899: Add basket link to static pages

### DIFF
--- a/lib/ChGovUk/Controllers/StaticPages.pm
+++ b/lib/ChGovUk/Controllers/StaticPages.pm
@@ -48,12 +48,12 @@ sub get_basket {
             failure        => sub {
                 my ($api, $tx) = @_;
                 debug "Error returned by getBasketLinks endpoint; not displaying basket link", [HOMEPAGE];
-                return $self->render_error($tx, 'failure', 'getting basket');
+                $self->render_error($tx, 'failure', 'getting basket');
             },
             error          => sub {
                 my ($api, $tx) = @_;
                 debug "Error returned by getBasketLinks endpoint; not displaying basket link", [HOMEPAGE];
-                return $self->render_error($tx, 'failure', 'getting basket');
+                $self->render_error($tx, 'failure', 'getting basket');
             }
         )->execute;
     } else {
@@ -109,7 +109,7 @@ sub render_error {
     my $error_code = $tx->error->{code} // 0;
     my $error_message = $tx->error->{message} // 0;
     my $message = (uc $error_type).' '.(defined $error_code ? "[$error_code] " : '').$action.': '.$error_message;
-    return $self->render_exception($message);
+    $self->render_exception($message);
 }
 
 #===============================================================================

--- a/lib/ChGovUk/Controllers/StaticPages.pm
+++ b/lib/ChGovUk/Controllers/StaticPages.pm
@@ -25,12 +25,12 @@ sub home {
                 else {
                     debug "User [%s] not enrolled for multi-item basket; not displaying basket link", $self->user_id, [HOMEPAGE];
                 }
-                $self->do_render($items, $show_basket_link);
+                $self->render_homepage($items, $show_basket_link);
             },
             not_authorised => sub {
                 my ($api, $tx) = @_;
                 debug "User not authenticated; not displaying basket link", [HOMEPAGE];
-                $self->do_render(0, undef);
+                $self->render_homepage(0, undef);
             },
             failure        => sub {
                 my ($api, $tx) = @_;
@@ -45,16 +45,12 @@ sub home {
         )->execute;
     } else {
         debug "User not signed in; not displaying basket link", [HOMEPAGE];
-        $self->do_render(0, undef);
+        $self->render_homepage(0, undef);
     }
 }
 
 sub render_filepath {
     my ($self) = @_;
-
-    debug "render_filepath: filepath = %s",  $self->param('filepath'), [HOMEPAGE];
-    my $path = 'static_pages/help/' . $self->param('filepath');
-    debug "render_filepath: \$path = %s",  $path, [HOMEPAGE];
 
     $self->render_later;
 
@@ -74,12 +70,12 @@ sub render_filepath {
                 else {
                     debug "User [%s] not enrolled for multi-item basket; not displaying basket link", $self->user_id, [HOMEPAGE];
                 }
-                $self->do_render_2($items, $show_basket_link, $path);
+                $self->render_static_page($items, $show_basket_link);
             },
             not_authorised => sub {
                 my ($api, $tx) = @_;
                 debug "User not authenticated; not displaying basket link", [HOMEPAGE];
-                $self->do_render_2(0, undef, $path);
+                $self->render_static_page(0, undef);
             },
             failure        => sub {
                 my ($api, $tx) = @_;
@@ -94,14 +90,14 @@ sub render_filepath {
         )->execute;
     } else {
         debug "User not signed in; not displaying basket link", [HOMEPAGE];
-        $self->do_render_2(0, undef, $path);
+        $self->render_static_page(0, undef);
     }
 }
 
-sub do_render {
+sub render_homepage {
     my ($self, $basket_items, $show_basket_link) = @_;
 
-    debug "do_render(%s, %s)", $basket_items, $show_basket_link [HOMEPAGE];
+    debug "render_homepage(%s, %s)", $basket_items, $show_basket_link [HOMEPAGE];
 
     my $search_type = 'all';
 
@@ -114,18 +110,17 @@ sub do_render {
     $self->render;
 }
 
-sub do_render_2 {
-    my ($self, $basket_items, $show_basket_link, $path) = @_;
+sub render_static_page {
+    my ($self, $basket_items, $show_basket_link) = @_;
 
-    debug "do_render_2(%s, %s, %s)", $basket_items, $show_basket_link, $path [HOMEPAGE];
+    debug "render_static_page(%s, %s)", $basket_items, $show_basket_link [HOMEPAGE];
 
     $self->stash(
         basket_items     => $basket_items,
         show_basket_link => $show_basket_link
     );
 
-    debug "stash AFTER = %s", Dumper($self->stash), [HOMEPAGE];
-
+    my $path = 'static_pages/help/' . $self->param('filepath');
     $self->render(template => $path);
 }
 

--- a/lib/ChGovUk/Controllers/StaticPages.pm
+++ b/lib/ChGovUk/Controllers/StaticPages.pm
@@ -3,6 +3,7 @@ package ChGovUk::Controllers::StaticPages;
 use CH::Perl;
 use Mojo::Base 'Mojolicious::Controller';
 use CH::Util::CVConstants;
+use Data::Dumper;
 
 #-------------------------------------------------------------------------------
 
@@ -50,12 +51,61 @@ sub home {
 
 sub render_filepath {
     my ($self) = @_;
+
+    debug "render_filepath: filepath = %s",  $self->param('filepath'), [HOMEPAGE];
+    my $path = 'static_pages/help/' . $self->param('filepath');
+    debug "render_filepath: \$path = %s",  $path, [HOMEPAGE];
+
+    $self->render_later;
+
+    if ($self->is_signed_in) {
+        $self->ch_api->basket->get->on(
+            success        => sub {
+                my ($api, $tx) = @_;
+
+                debug "success", [HOMEPAGE];
+
+                my $json = $tx->res->json;
+                my $show_basket_link = $json->{data}{enrolled} || undef;
+                my $items = scalar @{$json->{data}{items} || []};
+                if ($show_basket_link) {
+                    debug "User [%s] enrolled for multi-item basket; displaying basket link", $self->user_id, [HOMEPAGE];
+                }
+                else {
+                    debug "User [%s] not enrolled for multi-item basket; not displaying basket link", $self->user_id, [HOMEPAGE];
+                }
+                $self->do_render_2($items, $show_basket_link, $path);
+            },
+            # TODO BI-11899 What's wrong with this?
+            # not_authorised => sub {
+            #     my ($api, $tx) = @_;
+            #     debug "User not authenticated; not displaying basket link", [HOMEPAGE];
+            #     $self->do_render(0, undef);
+            # },
+            failure        => sub {
+                my ($api, $tx) = @_;
+                debug "Failure returned by getBasketLinks endpoint; not displaying basket link", [HOMEPAGE];
+                $self->do_render_2(0, undef, $path);
+            },
+            error          => sub {
+                my ($api, $tx) = @_;
+                debug "Error returned by getBasketLinks endpoint; not displaying basket link", [HOMEPAGE];
+                $self->do_render_2(0, undef, $path);
+            }
+        )->execute;
+    } else {
+        debug "User not signed in; not displaying basket link", [HOMEPAGE];
+        $self->do_render_2(0, undef, $path);
+    }
+
     my $path = 'static_pages/help/' . $self->param('filepath');
     $self->render(template => $path );
 }
 
 sub do_render {
     my ($self, $basket_items, $show_basket_link) = @_;
+
+    debug "do_render(%s, %s)", $basket_items, $show_basket_link [HOMEPAGE];
 
     my $search_type = 'all';
 
@@ -66,6 +116,21 @@ sub do_render {
         show_basket_link => $show_basket_link
     );
     $self->render;
+}
+
+sub do_render_2 {
+    my ($self, $basket_items, $show_basket_link, $path) = @_;
+
+    debug "do_render_2(%s, %s, %s)", $basket_items, $show_basket_link, $path [HOMEPAGE];
+
+    $self->stash(
+        basket_items     => $basket_items,
+        show_basket_link => $show_basket_link
+    );
+
+    debug "stash AFTER = %s", Dumper($self->stash), [HOMEPAGE];
+
+    $self->render(template => $path);
 }
 
 #===============================================================================

--- a/lib/ChGovUk/Controllers/StaticPages.pm
+++ b/lib/ChGovUk/Controllers/StaticPages.pm
@@ -97,9 +97,6 @@ sub render_filepath {
         debug "User not signed in; not displaying basket link", [HOMEPAGE];
         $self->do_render_2(0, undef, $path);
     }
-
-    my $path = 'static_pages/help/' . $self->param('filepath');
-    $self->render(template => $path );
 }
 
 sub do_render {

--- a/lib/ChGovUk/Controllers/StaticPages.pm
+++ b/lib/ChGovUk/Controllers/StaticPages.pm
@@ -35,12 +35,12 @@ sub home {
             failure        => sub {
                 my ($api, $tx) = @_;
                 debug "Error returned by getBasketLinks endpoint; not displaying basket link", [HOMEPAGE];
-                $self->do_render(0, undef);
+                return $self->render_error($tx, 'failure', 'getting basket');
             },
             error          => sub {
                 my ($api, $tx) = @_;
                 debug "Error returned by getBasketLinks endpoint; not displaying basket link", [HOMEPAGE];
-                $self->do_render(0, undef);
+                return $self->render_error($tx, 'failure', 'getting basket');
             }
         )->execute;
     } else {


### PR DESCRIPTION
* This should render the basket link when appropriate on static pages such as the `Is there anything wrong with this page?` page and the `Other document filings` page.
* Refactored home page basket link code in same controller to reduce code duplication.