### PR TITLE
Fix issue where page not rendering on failure and error of get basket

### DIFF
--- a/lib/ChGovUk/Controllers/Search/CompanyNameAvailability.pm
+++ b/lib/ChGovUk/Controllers/Search/CompanyNameAvailability.pm
@@ -107,63 +107,32 @@ sub get_basket() {
                     debug "User [%s] not enrolled for multi-item basket; not displaying basket link", $self->user_id, [COMPANY_NAME_AVAILABILITY];
                 }
                 $self->stash_basket_link($items, $show_basket_link);
-                if ($company_name) {
-                    debug "success: Calling perform_search()", [COMPANY_NAME_AVAILABILITY];
-                    $self->perform_search($company_name);
-                } else {
-                    debug "success: Rendering page", [COMPANY_NAME_AVAILABILITY];
-                    return $self->render(template => "company/company_name_availability/form");
-                }
-
+                $self->search_or_render($company_name, "success");
             },
             not_authorised => sub {
                 my ($api, $tx) = @_;
                 debug "GET basket not_authorised", [COMPANY_NAME_AVAILABILITY];
                 warn "User not authenticated; not displaying basket link", [COMPANY_NAME_AVAILABILITY];
                 $self->stash_basket_link(0, undef);
-                if ($company_name) {
-                    debug "not_authorised: Calling perform_search()", [COMPANY_NAME_AVAILABILITY];
-                    $self->perform_search($company_name);
-                } else {
-                    debug "not_authorised: Rendering page", [COMPANY_NAME_AVAILABILITY];
-                    return $self->render(template => "company/company_name_availability/form");
-                }
+                $self->search_or_render($company_name, "not_authorised");
             },
             failure        => sub {
                 my ($api, $tx) = @_;
                 log_error($tx, "failure");
                 $self->stash_basket_link(0, undef);
-                if ($company_name) {
-                    debug "failure: Calling perform_search()", [COMPANY_NAME_AVAILABILITY];
-                    $self->perform_search($company_name);
-                } else {
-                    debug "failure: Rendering page", [COMPANY_NAME_AVAILABILITY];
-                    return $self->render(template => "company/company_name_availability/form");
-                }
+                $self->search_or_render($company_name, "failure");
             },
             error          => sub {
                 my ($api, $tx) = @_;
                 log_error($tx, "error");
                 $self->stash_basket_link(0, undef);
-                if ($company_name) {
-                    debug "error: Calling perform_search()", [COMPANY_NAME_AVAILABILITY];
-                    $self->perform_search($company_name);
-                } else {
-                    debug "error: Rendering page", [COMPANY_NAME_AVAILABILITY];
-                    return $self->render(template => "company/company_name_availability/form");
-                }
+                $self->search_or_render($company_name, "error");
             }
         )->execute;
     } else {
         debug "User not signed in; not displaying basket link", [COMPANY_NAME_AVAILABILITY];
         $self->stash_basket_link(0, undef);
-        if ($company_name) {
-            debug "Not signed in: Calling perform_search()", [COMPANY_NAME_AVAILABILITY];
-            $self->perform_search($company_name);
-        } else {
-            debug "Not signed in: Rendering page", [COMPANY_NAME_AVAILABILITY];
-            return $self->render(template => "company/company_name_availability/form");
-        }
+        $self->search_or_render($company_name, "Not signed in");
     }
 }
 
@@ -183,6 +152,19 @@ sub log_error {
     my $error_message = $tx->error->{message} // 0;
     my $error = (defined $error_code ? "[$error_code] " : '').$error_message;
     error "%s returned by getBasketLinks endpoint: '%s'. Not displaying basket link.", uc $error_type, $error, [COMPANY_NAME_AVAILABILITY];
+}
+
+sub search_or_render {
+    my($self, $company_name, $log_type) = @_;
+
+    if ($company_name) {
+        debug "%s: Calling perform_search()", $log_type, [COMPANY_NAME_AVAILABILITY];
+        $self->perform_search($company_name);
+    } else {
+        debug "%s: Rendering page", $log_type, [COMPANY_NAME_AVAILABILITY];
+        return $self->render(template => "company/company_name_availability/form");
+    }
+
 }
 
 # =============================================================================

--- a/lib/ChGovUk/Controllers/Search/CompanyNameAvailability.pm
+++ b/lib/ChGovUk/Controllers/Search/CompanyNameAvailability.pm
@@ -29,7 +29,7 @@ sub company_name_availability {
 sub perform_search() {
     my ($self, $company_name) = @_;
 
-    debug "About to execute search", [HOMEPAGE];
+    debug "About to execute search", [COMPANY_NAME_AVAILABILITY];
     $self->ch_api->search->companies({
         'q'              => $company_name,
         'items_per_page' => DEFAULT_ITEMS_PER_PAGE,
@@ -54,7 +54,7 @@ sub perform_search() {
                                   : 'Company name availability checker - Find and update company information - GOV.UK'
             );
 
-            debug "search success , stash = %s", Dumper($self->stash), [HOMEPAGE];
+            debug "search success , stash = %s", Dumper($self->stash), [COMPANY_NAME_AVAILABILITY];
             return $self->render(template => "company/company_name_availability/form");
 
         },
@@ -72,7 +72,7 @@ sub perform_search() {
             # don't throw to the error page show a message inline
             $self->stash(query => $company_name, show_error => 1);
 
-            debug "search failure, stash = %s", Dumper($self->stash), [HOMEPAGE];
+            debug "search failure, stash = %s", Dumper($self->stash), [COMPANY_NAME_AVAILABILITY];
             return $self->render(template => "company/company_name_availability/form");
 
         },
@@ -82,7 +82,7 @@ sub perform_search() {
             my $message = "Error retrieving search results: $error";
             error '%s', $message;
 
-            debug "search error, stash = %s", Dumper($self->stash), [HOMEPAGE];
+            debug "search error, stash = %s", Dumper($self->stash), [COMPANY_NAME_AVAILABILITY];
             return $self->render_exception($message);
         },
     )->execute;
@@ -133,11 +133,25 @@ sub get_basket() {
                 my ($api, $tx) = @_;
                 log_error($tx, "failure");
                 $self->stash_basket_link(0, undef);
+                if ($company_name) {
+                    debug "failure: Calling perform_search()", [COMPANY_NAME_AVAILABILITY];
+                    $self->perform_search($company_name);
+                } else {
+                    debug "failure: Rendering page", [COMPANY_NAME_AVAILABILITY];
+                    return $self->render(template => "company/company_name_availability/form");
+                }
             },
             error          => sub {
                 my ($api, $tx) = @_;
                 log_error($tx, "error");
                 $self->stash_basket_link(0, undef);
+                if ($company_name) {
+                    debug "error: Calling perform_search()", [COMPANY_NAME_AVAILABILITY];
+                    $self->perform_search($company_name);
+                } else {
+                    debug "error: Rendering page", [COMPANY_NAME_AVAILABILITY];
+                    return $self->render(template => "company/company_name_availability/form");
+                }
             }
         )->execute;
     } else {

--- a/lib/ChGovUk/Controllers/Search/CompanyNameAvailability.pm
+++ b/lib/ChGovUk/Controllers/Search/CompanyNameAvailability.pm
@@ -164,7 +164,6 @@ sub search_or_render {
         debug "%s: Rendering page", $log_type, [COMPANY_NAME_AVAILABILITY];
         return $self->render(template => "company/company_name_availability/form");
     }
-
 }
 
 # =============================================================================


### PR DESCRIPTION
- Correct log type from `HOMEPAGE` to `COMPANY_NAME_AVAILABILITY` to detail where logs are spawned
- Ensure rendering of page on errors and failures from the call to getBasket
- Reduce code duplication

Resolves: GCI-2385