### PR TITLE
ROE-1694 - TL - Suppress display of hyperlink if no company number

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Resolve project dependencies by 'building' the service:
 $ make build
 ```
 
+If a build error is encountered during the 'test' phase, running the following command may fix it:
+
+```
+$ aws s3 cp s3://release.ch.gov.uk/ch.gov.uk-deps/ch.gov.uk-deps-1.1.5.zip . && unzip ch.gov.uk-deps-1.1.5.zip -d <<PATH-TO-DOCKER-CHS-DEVELOPMENT-REPO>>/repositories/ch-gov-uk/local;
+```
+
 #### Running the service
 
 Run the service using the provided script:

--- a/templates/includes/transactions.tx
+++ b/templates/includes/transactions.tx
@@ -11,9 +11,11 @@
         <div class="one-filing rejected">
         % if $transaction.company_name {
             <h2 class="heading-medium">
-                <a id="company-name-<% $~transaction.count %>" href="/company/<% $transaction.company_number %>"><% $transaction.company_name %></a>
                 % if $transaction.company_number {
+                    <a id="company-name-<% $~transaction.count %>" href="/company/<% $transaction.company_number %>"><% $transaction.company_name %></a>
                     <span id="company-number-<% $~transaction.count %>">Company number <Strong><% $transaction.company_number %></Strong></span>
+                % } else {
+                    <span id="company-name-<% $~transaction.count %>"><strong><% $transaction.company_name %></strong></span>
                 % }
             </h2>
         % }    


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1694

* Hyperlink of company name on Your filings screen does not
work if company number is not present in the transaction.
* This is the case for OE registrations, new incs etc.
* Company name now no longer displays with a hyperlink if
company number is not present
* README file updated with help suggestion if 'make' fails