### PR TITLE
DB-1952 Add required second argument to trackEvent

### DIFF
--- a/templates/company/filing_history/view_content_certified.html.tx
+++ b/templates/company/filing_history/view_content_certified.html.tx
@@ -70,7 +70,7 @@
                             <input type="submit" class="select-document-button-link" id="add-document-to-order-<% $item.transaction_id%>"
                                 value="Select document"
                                 % if $c.config.piwik.embed {
-                                        onclick="javascript:_paq.push(['trackEvent', 'AddDocumentToOrder']);"
+                                        onclick="javascript:_paq.push(['trackEvent', 'AddDocumentToOrder', 'AddDocumentToOrder']);"
                                 % }
                                 >
                             </input>

--- a/templates/company/follow/list.html.tx
+++ b/templates/company/follow/list.html.tx
@@ -15,13 +15,13 @@
             <div class="form-group">
                 <a href="<% $c.url_for('company_follow') %>" class="button" id="follow-company-confirmed""
                     % if $c.config.piwik.embed {
-                        onclick="javascript:_paq.push(['trackEvent', 'FollowCompanyConfirmed']);"
+                        onclick="javascript:_paq.push(['trackEvent', 'FollowCompanyConfirmed', 'FollowCompanyConfirmed']);"
                     % }
                 >Yes</a>
                 <p class="action-link">
                     <a href="<% $c.url_for('company') %>" id="follow-company-cancelled"
                         % if $c.config.piwik.embed {
-                            onclick="javascript:_paq.push(['trackEvent', 'FollowCompanyCancelled']);"
+                            onclick="javascript:_paq.push(['trackEvent', 'FollowCompanyCancelled', 'FollowCompanyCancelled']);"
                         % }
                     >Cancel</a>
                 </p>


### PR DESCRIPTION
[DB-1952](https://companieshouse.atlassian.net/browse/DB-1952)

trackEvent requires two arguments: category and action Without them it fails validation and gives an error in the javascript console and no event is sent to Matomo. It probably used to work before Matomo fixed the validation in 2018. https://github.com/matomo-org/matomo/pull/15980/files

[DB-1952]: https://companieshouse.atlassian.net/browse/DB-1952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ