### PR TITLE
BI-13246 - Add annual statement overdue indicators for ROE companies

### DIFF
--- a/templates/company/view.html.tx
+++ b/templates/company/view.html.tx
@@ -252,54 +252,55 @@
          % }
       % }
 
-      % if $company.confirmation_statement.size() { 
-         % if $company.type == "registered-overseas-entity" {
+    % if $company.confirmation_statement.size() {
+        % if $company.type == "registered-overseas-entity" {
             <dl class="column-two-thirds">
             <h2 class="heading-medium"><strong>Annual statement</strong></h2>
             % if $company.confirmation_statement.next_made_up_to {
                 <p>
-                %if ($company.confirmation_statement.last_made_up_to) {
-                %l('Next statement date')
-                %} else {
-                %l('First statement date')
-                %}
-                <strong><% $c.isodate_as_string($company.confirmation_statement.next_made_up_to) %></strong> <br>
-                due by <strong><% $c.isodate_as_string($company.confirmation_statement.next_due) %></strong>
-            </p>
-            %  }
-            %  if $company.confirmation_statement.last_made_up_to {
-                  <p>
-                    <% l('Last statement dated') %> <strong><% $c.isodate_as_string($company.confirmation_statement.last_made_up_to) %></strong>
-                  </p>
-            %  }
-            <dl>
-         % } 
-         % else {
-         <div class="column-half">
-         %  if $company.confirmation_statement.overdue == 1 {
-                <div class="help-notice overdue"><h2 class="heading-medium">Confirmation statement overdue</h2></div>
-         %  } else {
-                <h2 class="heading-medium"><strong>Confirmation statement</strong></h2>
-         %  }
-         % if $company.confirmation_statement.next_made_up_to {
-              <p>
-              % if ($company.confirmation_statement.last_made_up_to) {
-              %    l('Next statement date')
-              % } else {
-              %     l('First statement date')
-              % }
-              <strong><% $c.isodate_as_string($company.confirmation_statement.next_made_up_to) %></strong> <br>
-              due by <strong><% $c.isodate_as_string($company.confirmation_statement.next_due) %></strong>
-              </p>
-         %  }
-         %  if $company.confirmation_statement.last_made_up_to {
-                <p>
-                <% l('Last statement dated') %> <strong><% $c.isodate_as_string($company.confirmation_statement.last_made_up_to) %></strong>
+                    % if ($company.confirmation_statement.last_made_up_to) {
+                        %l('Next statement date')
+                    % } else {
+                        %l('First statement date')
+                    % }
+                    <strong><% $c.isodate_as_string($company.confirmation_statement.next_made_up_to) %></strong> <br>
+                    due by <strong><% $c.isodate_as_string($company.confirmation_statement.next_due) %></strong>
                 </p>
-         %  }
-         </div>
+            % }
+            % if $company.confirmation_statement.last_made_up_to {
+                <p>
+                    <% l('Last statement dated') %> <strong><% $c.isodate_as_string($company.confirmation_statement.last_made_up_to) %></strong>
+                </p>
+            % }
+            <dl>
         % } 
-      % }
+        % else {
+            <div class="column-half">
+                % if $company.confirmation_statement.overdue == 1 {
+                    <div class="help-notice overdue"><h2 class="heading-medium">Confirmation statement overdue</h2></div>
+                % } else {
+                    <h2 class="heading-medium"><strong>Confirmation statement</strong></h2>
+                % }
+
+                % if $company.confirmation_statement.next_made_up_to {
+                    <p>
+                        % if ($company.confirmation_statement.last_made_up_to) {
+                        %    l('Next statement date')
+                        % } else {
+                        %    l('First statement date')
+                        % }
+                        <strong><% $c.isodate_as_string($company.confirmation_statement.next_made_up_to) %></strong> <br>
+                        due by <strong><% $c.isodate_as_string($company.confirmation_statement.next_due) %></strong>
+                    </p>
+                % }
+                % if $company.confirmation_statement.last_made_up_to {
+                    <p>
+                        <% l('Last statement dated') %> <strong><% $c.isodate_as_string($company.confirmation_statement.last_made_up_to) %></strong>
+                    </p>
+                % }
+            </div>
+        % }
+    % }
 
       % if $company.annual_return.size() && ! $company.confirmation_statement.last_made_up_to {
             <div class="column-half">

--- a/templates/company/view.html.tx
+++ b/templates/company/view.html.tx
@@ -255,7 +255,13 @@
     % if $company.confirmation_statement.size() {
         % if $company.type == "registered-overseas-entity" {
             <dl class="column-two-thirds">
-            <h2 class="heading-medium"><strong>Annual statement</strong></h2>
+
+            % if $company.confirmation_statement.overdue == 1 {
+                <div class="help-notice overdue"><h2 class="heading-medium">Annual statement overdue</h2></div>
+            % } else {
+                <h2 class="heading-medium"><strong>Annual statement</strong></h2>
+            % }
+
             % if $company.confirmation_statement.next_made_up_to {
                 <p>
                     % if ($company.confirmation_statement.last_made_up_to) {


### PR DESCRIPTION
Add annual statement overdue indicators for ROE companies and clean up formatting for annual/confirmation statement section of template.

**Note**: The code change is present in the second commit. The first commit relates to formatting.

**Resolves**: BI-13246