### PR TITLE
Add appropriate address statement [ECCT-516]

### DIFF
--- a/lib/ChGovUk/Controllers/Company/Transactions/ChangeRegisteredOfficeAddress.pm
+++ b/lib/ChGovUk/Controllers/Company/Transactions/ChangeRegisteredOfficeAddress.pm
@@ -43,7 +43,7 @@ sub get {
         success => sub {
             my ($api, $tx) = @_;
             my $addr = ChGovUk::Models::Address->new->from_api_hash($tx->success->json);
-            $self->stash(old_address => $addr->as_string, po_box => $addr->po_box, care_of => $addr->care_of, disable_header_search => 1, etag => $addr->etag, po_box_enabled => !$ecct);
+            $self->stash(old_address => $addr->as_string, po_box => $addr->po_box, care_of => $addr->care_of, disable_header_search => 1, etag => $addr->etag, ecct_disabled => !$ecct);
             $self->render(template => 'company/transactions/change_registered_office_address');
         }
     )->execute;

--- a/lib/ChGovUk/Controllers/Company/Transactions/ChangeRegisteredOfficeAddress.pm
+++ b/lib/ChGovUk/Controllers/Company/Transactions/ChangeRegisteredOfficeAddress.pm
@@ -43,7 +43,7 @@ sub get {
         success => sub {
             my ($api, $tx) = @_;
             my $addr = ChGovUk::Models::Address->new->from_api_hash($tx->success->json);
-            $self->stash(old_address => $addr->as_string, po_box => $addr->po_box, care_of => $addr->care_of, disable_header_search => 1, etag => $addr->etag, ecct_disabled => !$ecct);
+            $self->stash(old_address => $addr->as_string, po_box => $addr->po_box, care_of => $addr->care_of, disable_header_search => 1, etag => $addr->etag, ecct_enabled => $ecct);
             $self->render(template => 'company/transactions/change_registered_office_address');
         }
     )->execute;

--- a/templates/company/transactions/appropriate_address_statement.html.tx
+++ b/templates/company/transactions/appropriate_address_statement.html.tx
@@ -1,4 +1,4 @@
-% if $include_appropriate_addr_summary {
+% if $show_appropriate_addr_statement {
       % $form.checkbox ( label => 'The new registered office address is an appropriate address as outlined in section 86(2) of the Companies Act 2006.', name => 'address[statement]', class => 'block-label selection-button-checkbox');
       <details class="govuk-details" role="group">
               <summary class="govuk-details__summary" role="button" aria-controls="details-content" aria-expanded="true">

--- a/templates/company/transactions/appropriate_address_statement.html.tx
+++ b/templates/company/transactions/appropriate_address_statement.html.tx
@@ -1,0 +1,16 @@
+% if $include_appropriate_addr_summary {
+      <details class="govuk-details" role="group">
+              <summary class="govuk-details__summary" role="button" aria-controls="details-content" aria-expanded="true">
+                <span class="govuk-details__summary-text">
+                  What does 'appropriate address' mean?
+                </span>
+              </summary>
+              <div class="govuk-details__text" id="company-snapshot-details-content" aria-hidden="false">
+                <p id="snapshot-list">An address is an 'appropriate address' if, in the ordinary course of events:</p>
+                <ul class="govuk-list govuk-list--bullet">
+                  <li>a document addressed to the company, and delivered there by hand or by post, would be expected to come to the attention of a person acting on behalf of the company, and</li>
+                  <li>a person can get an acknowledgement of delivery, to record the delivery of documents to the new registered office address.</li>
+                </ul>
+              </div>
+      </details>
+% }

--- a/templates/company/transactions/appropriate_address_statement.html.tx
+++ b/templates/company/transactions/appropriate_address_statement.html.tx
@@ -1,4 +1,5 @@
 % if $include_appropriate_addr_summary {
+      % $form.checkbox ( label => 'The new registered office address is an appropriate address as outlined in section 86(2) of the Companies Act 2006.', name => 'address[statement]', class => 'block-label selection-button-checkbox');
       <details class="govuk-details" role="group">
               <summary class="govuk-details__summary" role="button" aria-controls="details-content" aria-expanded="true">
                 <span class="govuk-details__summary-text">

--- a/templates/company/transactions/appropriate_address_statement.html.tx
+++ b/templates/company/transactions/appropriate_address_statement.html.tx
@@ -1,17 +1,13 @@
-% if $show_appropriate_addr_statement {
-      % $form.checkbox ( label => 'The new registered office address is an appropriate address as outlined in section 86(2) of the Companies Act 2006.', name => 'address[statement]', class => 'block-label selection-button-checkbox');
-      <details class="govuk-details" role="group">
-              <summary class="govuk-details__summary" role="button" aria-controls="details-content" aria-expanded="true">
-                <span class="govuk-details__summary-text">
-                  What does 'appropriate address' mean?
-                </span>
-              </summary>
-              <div class="govuk-details__text" id="change-address-appropriate-address-statement" aria-hidden="false">
-                <p id="snapshot-list">An address is an 'appropriate address' if, in the ordinary course of events:</p>
-                <ul class="govuk-list govuk-list--bullet">
-                  <li>a document addressed to the company, and delivered there by hand or by post, would be expected to come to the attention of a person acting on behalf of the company, and</li>
-                  <li>a person can get an acknowledgement of delivery, to record the delivery of documents to the new registered office address.</li>
-                </ul>
-              </div>
-      </details>
-% }
+% $form.checkbox ( label => 'The new registered office address is an appropriate address as outlined in section 86(2) of the Companies Act 2006.', name => 'address[statement]', class => 'block-label selection-button-checkbox');
+<details class="govuk-details" role="group">
+    <summary class="govuk-details__summary" role="button" aria-controls="details-content" aria-expanded="true">
+        <span class="govuk-details__summary-text">What does 'appropriate address' mean?</span>
+    </summary>
+    <div class="govuk-details__text" id="change-address-appropriate-address-statement" aria-hidden="false">
+        <p id="snapshot-list">An address is an 'appropriate address' if, in the ordinary course of events:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>a document addressed to the company, and delivered there by hand or by post, would be expected to come to the attention of a person acting on behalf of the company, and</li>
+            <li>a person can get an acknowledgement of delivery, to record the delivery of documents to the new registered office address.</li>
+        </ul>
+    </div>
+</details>

--- a/templates/company/transactions/appropriate_address_statement.html.tx
+++ b/templates/company/transactions/appropriate_address_statement.html.tx
@@ -5,7 +5,7 @@
                   What does 'appropriate address' mean?
                 </span>
               </summary>
-              <div class="govuk-details__text" id="company-snapshot-details-content" aria-hidden="false">
+              <div class="govuk-details__text" id="change-address-appropriate-address-statement" aria-hidden="false">
                 <p id="snapshot-list">An address is an 'appropriate address' if, in the ordinary course of events:</p>
                 <ul class="govuk-list govuk-list--bullet">
                   <li>a document addressed to the company, and delivered there by hand or by post, would be expected to come to the attention of a person acting on behalf of the company, and</li>

--- a/templates/company/transactions/change_registered_office_address.html.tx
+++ b/templates/company/transactions/change_registered_office_address.html.tx
@@ -3,11 +3,14 @@
     %  include 'company/transactions/current_address.html.tx' { form => $form }
 % }
 
+% my $bullet_point1 = "a document addressed to the company, and delivered there by hand or by post, would be expected to come to the attention of a person acting on behalf of the company, and"
+% my $bullet_point2 = "a person can get an acknowledgement of delivery, to record the delivery of documents to the new registered office address."
 % around form_content -> {
 <fieldset>
     <legend class="heading-medium text">What is the new address of the company?</legend>
     % $c.include_later('includes/forms/errors', form => $form, form_title => 'Filing Error');
     % include 'includes/forms/address.tx' { form => $form, name => 'address', include_po_box => $po_box_enabled }
+    % include 'company/transactions/appropriate_address_statement.html.tx' { include_appropriate_addr_summary => !$po_box_enabled }
     % $form.hidden_field( name => 'address[etag]', value => $etag );
 </fieldset>
 % }

--- a/templates/company/transactions/change_registered_office_address.html.tx
+++ b/templates/company/transactions/change_registered_office_address.html.tx
@@ -1,5 +1,7 @@
 % cascade company::transactions::transaction { title => $company.company_name ~' change of registered office address - Find and update company information - GOV.UK', form => $c.form( model => $transaction.model ), require_js => 'transactions/change-registered-office-address', submit_label => "Submit changes" }
 % before form_content -> {
+    <script src='//<% $cdn_url %>/javascripts/vendor/selection-buttons.js'></script> <!-- Needed for new GDS-style radio buttons and checkboxes -->
+    <script src='//<% $cdn_url %>/javascripts/vendor/application.js'></script>  <!-- Needed for new GDS-style radio buttons and checkboxes -->
     %  include 'company/transactions/current_address.html.tx' { form => $form }
 % }
 

--- a/templates/company/transactions/change_registered_office_address.html.tx
+++ b/templates/company/transactions/change_registered_office_address.html.tx
@@ -9,8 +9,8 @@
 <fieldset>
     <legend class="heading-medium text">What is the new address of the company?</legend>
     % $c.include_later('includes/forms/errors', form => $form, form_title => 'Filing Error');
-    % include 'includes/forms/address.tx' { form => $form, name => 'address', include_po_box => $po_box_enabled }
-    % include 'company/transactions/appropriate_address_statement.html.tx' { include_appropriate_addr_summary => !$po_box_enabled }
+    % include 'includes/forms/address.tx' { form => $form, name => 'address', include_po_box => $ecct_disabled }
+    % include 'company/transactions/appropriate_address_statement.html.tx' { show_appropriate_addr_statement => !$ecct_disabled }
     % $form.hidden_field( name => 'address[etag]', value => $etag );
 </fieldset>
 % }

--- a/templates/company/transactions/change_registered_office_address.html.tx
+++ b/templates/company/transactions/change_registered_office_address.html.tx
@@ -9,8 +9,10 @@
 <fieldset>
     <legend class="heading-medium text">What is the new address of the company?</legend>
     % $c.include_later('includes/forms/errors', form => $form, form_title => 'Filing Error');
-    % include 'includes/forms/address.tx' { form => $form, name => 'address', include_po_box => $ecct_disabled }
-    % include 'company/transactions/appropriate_address_statement.html.tx' { show_appropriate_addr_statement => !$ecct_disabled }
+    % include 'includes/forms/address.tx' { form => $form, name => 'address', include_po_box => !$ecct_enabled };
+    % if $ecct_enabled {
+        % include 'company/transactions/appropriate_address_statement.html.tx'
+    % }
     % $form.hidden_field( name => 'address[etag]', value => $etag );
 </fieldset>
 % }

--- a/templates/company/transactions/change_registered_office_address.html.tx
+++ b/templates/company/transactions/change_registered_office_address.html.tx
@@ -3,8 +3,6 @@
     %  include 'company/transactions/current_address.html.tx' { form => $form }
 % }
 
-% my $bullet_point1 = "a document addressed to the company, and delivered there by hand or by post, would be expected to come to the attention of a person acting on behalf of the company, and"
-% my $bullet_point2 = "a person can get an acknowledgement of delivery, to record the delivery of documents to the new registered office address."
 % around form_content -> {
 <fieldset>
     <legend class="heading-medium text">What is the new address of the company?</legend>

--- a/templates/includes/forms/checkbox.html.tx
+++ b/templates/includes/forms/checkbox.html.tx
@@ -1,11 +1,11 @@
-<p class="<% if $has_errors { %>validation <%} %>option group">
+<div class="form-group <% if $has_errors { %>error <%} %>">
     % if $has_errors {
     %   for $errors->$error {
           <span class="error-message" id="<% $error.id %>"><% $error.text %></span>
     %   }
     % }
-    <label id="<% $id %>-label" for="<% $id %>">
+    <label id="<% $id %>-label" for="<% $id %>" class="<% $class %>">
     <input type="checkbox" id="<% $id %>" name="<% $name %>" value="1" <% if $value || $c.param($name) { %>checked="checked"<% } %> />
-	<% $label %>
-	</label>
-</p>
+    <% $label %>
+    </label>
+</div>


### PR DESCRIPTION
Added checkbox & summary text for appropriate address statement to registered office address change, to be shown only when property ecct (FEATURE_FLAG_ENABLE_ECCT_01092023) is set.  (Data not yet used in onward code, to be addressed in separate ticket).

Modified existing checkbox.html.tx to support this - so far this appears
only to be used by secure_address.tx, which does not itself appear to be
used.