### PR TITLE
Update error message display [ECCT-547]

### DIFF
--- a/templates/company/transactions/change_registered_office_address.html.tx
+++ b/templates/company/transactions/change_registered_office_address.html.tx
@@ -8,7 +8,6 @@
 % around form_content -> {
 <fieldset>
     <legend class="heading-medium text">What is the new address of the company?</legend>
-    % $c.include_later('includes/forms/errors', form => $form, form_title => 'Filing Error');
     % include 'includes/forms/address.tx' { form => $form, name => 'address', include_po_box => !$ecct_enabled };
     % if $ecct_enabled {
         % include 'company/transactions/appropriate_address_statement.html.tx'

--- a/templates/company/transactions/transaction.tx
+++ b/templates/company/transactions/transaction.tx
@@ -3,6 +3,8 @@
 
     % include "company/transactions/filing_for.html.tx"
 
+    % $c.include_later('includes/forms/errors', form => $form, form_title => 'There is a problem');
+
 	<header class="text">
 		<h1 class="heading-xlarge" id="page-content">Change of registered office address</h1>
 		% block additional_header -> {}

--- a/templates/includes/forms/errors.html.tx
+++ b/templates/includes/forms/errors.html.tx
@@ -12,13 +12,11 @@
     % }
 
     % if $form.errors_count() > 0 {
+        <script>let oldtitle = document.title;  document.title = "Error: "+oldtitle;</script>
         <div class="error-summary" role="group" tabindex="-1">
             <h2 class="heading-medium error-summary-heading">
                 <% $form_title %>
             </h2>
-            <p>
-                This form has errors
-            </p>
             <ul class="error-summary-list">
             % for $form.errors -> $error {
                 <li><a href="#<% $error.id %>"><% $error.text %></a></li>


### PR DESCRIPTION
Updated error message handling:
- error box is placed above page heading
- error box title corrected & additional text removed
- page title updated with 'Error: ' prefix - note that this was done as script since title is not currently re-rendered when errors are returned