### PR TITLE
Feature/ecct 540 add matomo tracking to new ad01 statement

### DIFF
--- a/templates/company/transactions/appropriate_address_statement.html.tx
+++ b/templates/company/transactions/appropriate_address_statement.html.tx
@@ -1,4 +1,4 @@
-% $form.checkbox ( label => 'The new registered office address is an appropriate address as outlined in section 86(2) of the Companies Act 2006.', name => 'address[statement]', class => 'block-label selection-button-checkbox');
+% $form.checkbox ( label => 'The new registered office address is an appropriate address as outlined in section 86(2) of the Companies Act 2006.', id => 'appropriateAddress', name => 'address[statement]', class => 'block-label selection-button-checkbox', ecct_enabled => $ecct_enabled, piwik_embed => $piwik_embed);
 <details class="govuk-details" role="group">
     <summary class="govuk-details__summary" role="button" aria-controls="details-content" aria-expanded="true">
         <span class="govuk-details__summary-text">What does 'appropriate address' mean?</span>

--- a/templates/company/transactions/change_registered_office_address.html.tx
+++ b/templates/company/transactions/change_registered_office_address.html.tx
@@ -1,4 +1,4 @@
-% cascade company::transactions::transaction { title => $company.company_name ~' change of registered office address - Find and update company information - GOV.UK', form => $c.form( model => $transaction.model ), require_js => 'transactions/change-registered-office-address', submit_label => "Submit changes" }
+% cascade company::transactions::transaction { title => $company.company_name ~' change of registered office address - Find and update company information - GOV.UK', form => $c.form( model => $transaction.model ), require_js => 'transactions/change-registered-office-address', submit_label => "Submit changes", ecct_enabled => $ecct_enabled }
 % before form_content -> {
     <script src='//<% $cdn_url %>/javascripts/vendor/selection-buttons.js'></script> <!-- Needed for new GDS-style radio buttons and checkboxes -->
     <script src='//<% $cdn_url %>/javascripts/vendor/application.js'></script>  <!-- Needed for new GDS-style radio buttons and checkboxes -->
@@ -10,7 +10,7 @@
     <legend class="heading-medium text">What is the new address of the company?</legend>
     % include 'includes/forms/address.tx' { form => $form, name => 'address', include_po_box => !$ecct_enabled };
     % if $ecct_enabled {
-        % include 'company/transactions/appropriate_address_statement.html.tx'
+        % include 'company/transactions/appropriate_address_statement.html.tx' { ecct_enabled => $ecct_enabled, piwik_embed => $c.config.piwik.embed };
     % }
     % $form.hidden_field( name => 'address[etag]', value => $etag );
 </fieldset>

--- a/templates/company/transactions/transaction.tx
+++ b/templates/company/transactions/transaction.tx
@@ -15,7 +15,7 @@
 	% block form_content -> {}
 
 	% block form_submit -> {
-	%   include "includes/forms/transaction_submit_buttons.html.tx";
+	%   include "includes/forms/transaction_submit_buttons.html.tx" { ecct_enabled => $ecct_enabled };
 	% }
 
 	% $form.end;

--- a/templates/includes/forms/checkbox.html.tx
+++ b/templates/includes/forms/checkbox.html.tx
@@ -5,7 +5,13 @@
     %   }
     % }
     <label id="<% $id %>-label" for="<% $id %>" class="<% $class %>">
-    <input type="checkbox" id="<% $id %>" name="<% $name %>" value="1" <% if $value || $c.param($name) { %>checked="checked"<% } %> />
+    % if $ecct_enabled {
+        % my $eventDesc = 'appropriate-office-address-statement'
+        <input type="checkbox" id="<% $id %>" name="<% $name %>" value="1" <% if $value || $c.param($name) { %>checked="checked"<% } %> <% if $piwik_embed { %> onclick="javascript:_paq.push(['trackEvent', '<% $eventDesc %>', 'checkbox-clicked'])"<% } %>/>
+    % }
+    % else {
+        <input type="checkbox" id="<% $id %>" name="<% $name %>" value="1" <% if $value || $c.param($name) { %>checked="checked"<% } %> />
+    % }
     <% $label %>
     </label>
 </div>

--- a/templates/includes/forms/checkbox.html.tx
+++ b/templates/includes/forms/checkbox.html.tx
@@ -15,9 +15,9 @@
         if (ecct_enabled) {
             var checkboxValue = document.getElementById("appropriateAddress").checked;
             if (checkboxValue == false) {
-                _paq.push(['trackEvent', 'appropriate-office-address-statement-checkbox-clicked', 'false']);
+                _paq.push(['trackEvent', 'appropriate-office-address-statement-checkbox-clicked', 'unticked']);
             } else {
-                _paq.push(['trackEvent', 'appropriate-office-address-statement-checkbox-clicked', 'true']);
+                _paq.push(['trackEvent', 'appropriate-office-address-statement-checkbox-clicked', 'ticked']);
             }
         }
     }

--- a/templates/includes/forms/checkbox.html.tx
+++ b/templates/includes/forms/checkbox.html.tx
@@ -11,14 +11,11 @@
 </div>
 <script type="text/javascript">
     function writeCheckboxEvent() {
-        var ecct_enabled = '//<% $ecct_enabled %>';
-        if (ecct_enabled) {
-            var checkboxValue = document.getElementById("appropriateAddress").checked;
-            if (checkboxValue == false) {
-                _paq.push(['trackEvent', 'appropriate-office-address-statement-checkbox-clicked', 'unticked']);
-            } else {
-                _paq.push(['trackEvent', 'appropriate-office-address-statement-checkbox-clicked', 'ticked']);
-            }
+        var checkboxValue = document.getElementById("appropriateAddress").checked;
+        if (checkboxValue == false) {
+            _paq.push(['trackEvent', 'appropriate-office-address-statement-checkbox-clicked', 'unticked']);
+        } else {
+            _paq.push(['trackEvent', 'appropriate-office-address-statement-checkbox-clicked', 'ticked']);
         }
     }
 </script>

--- a/templates/includes/forms/checkbox.html.tx
+++ b/templates/includes/forms/checkbox.html.tx
@@ -5,13 +5,20 @@
     %   }
     % }
     <label id="<% $id %>-label" for="<% $id %>" class="<% $class %>">
-    % if $ecct_enabled {
-        % my $eventDesc = 'appropriate-office-address-statement'
-        <input type="checkbox" id="<% $id %>" name="<% $name %>" value="1" <% if $value || $c.param($name) { %>checked="checked"<% } %> <% if $piwik_embed { %> onclick="javascript:_paq.push(['trackEvent', '<% $eventDesc %>', 'checkbox-clicked'])"<% } %>/>
-    % }
-    % else {
-        <input type="checkbox" id="<% $id %>" name="<% $name %>" value="1" <% if $value || $c.param($name) { %>checked="checked"<% } %> />
-    % }
+    <input type="checkbox" id="<% $id %>" name="<% $name %>" value="1" <% if $value || $c.param($name) { %>checked="checked"<% } %> <% if $piwik_embed { %> onclick="writeCheckboxEvent()" <% } %> />
     <% $label %>
     </label>
 </div>
+<script type="text/javascript">
+    function writeCheckboxEvent() {
+        var ecct_enabled = '//<% $ecct_enabled %>';
+        if (ecct_enabled) {
+            var checkboxValue = document.getElementById("appropriateAddress").checked;
+            if (checkboxValue == false) {
+                _paq.push(['trackEvent', 'appropriate-office-address-statement-checkbox-clicked', 'false']);
+            } else {
+                _paq.push(['trackEvent', 'appropriate-office-address-statement-checkbox-clicked', 'true']);
+            }
+        }
+    }
+</script>

--- a/templates/includes/forms/errors.html.tx
+++ b/templates/includes/forms/errors.html.tx
@@ -20,6 +20,10 @@
             <ul class="error-summary-list">
             % for $form.errors -> $error {
                 <li><a href="#<% $error.id %>"><% $error.text %></a></li>
+                % my $errorID = lc($error.id);
+                % if ($errorID == 'address-statement-must_be_true-error') {
+                      <script>var _paq = _paq || [];_paq.push(['trackEvent', 'error-on-appropriate-office-address-statement', '<% $error.text %>']);</script>
+                % }
             % }
             </ul>
         </div>

--- a/templates/includes/forms/submit_button.html.tx
+++ b/templates/includes/forms/submit_button.html.tx
@@ -1,5 +1,5 @@
 % if $ecct_enabled {
-    % my $eventDesc = 'change-registered-office-address'
+    % my $eventDesc = 'change-of-registered-office-address'
      <input type="submit" id="<% $id %>" name="<% $name %>" value="<% $label %>" class="<% if ( $class ) { %><%$class%><% } else { %>button<% } %>" <% if $disabled { %>disabled="disabled"<% } %> <% if $piwik_embed { %> onclick="javascript:_paq.push(['trackEvent', '<% $eventDesc %>', 'submit-button-clicked']);"<% } %>/>
 % }
 % else {

--- a/templates/includes/forms/submit_button.html.tx
+++ b/templates/includes/forms/submit_button.html.tx
@@ -1,1 +1,7 @@
+% if $ecct_enabled {
+    % my $eventDesc = 'change-registered-office-address'
+     <input type="submit" id="<% $id %>" name="<% $name %>" value="<% $label %>" class="<% if ( $class ) { %><%$class%><% } else { %>button<% } %>" <% if $disabled { %>disabled="disabled"<% } %> <% if $piwik_embed { %> onclick="javascript:_paq.push(['trackEvent', '<% $eventDesc %>', 'submit-button-clicked']);"<% } %>/>
+% }
+% else {
     <input type="submit" id="<% $id %>" name="<% $name %>" value="<% $label %>" class="<% if ( $class ) { %><%$class%><% } else { %>button<% } %>" <% if $disabled { %>disabled="disabled"<% } %>/>
+% }

--- a/templates/includes/forms/submit_button.html.tx
+++ b/templates/includes/forms/submit_button.html.tx
@@ -1,6 +1,5 @@
 % if $ecct_enabled {
-    % my $eventDesc = 'change-of-registered-office-address'
-     <input type="submit" id="<% $id %>" name="<% $name %>" value="<% $label %>" class="<% if ( $class ) { %><%$class%><% } else { %>button<% } %>" <% if $disabled { %>disabled="disabled"<% } %> <% if $piwik_embed { %> onclick="javascript:_paq.push(['trackEvent', '<% $eventDesc %>', 'submit-button-clicked']);"<% } %>/>
+     <input type="submit" id="<% $id %>" name="<% $name %>" value="<% $label %>" class="<% if ( $class ) { %><%$class%><% } else { %>button<% } %>" <% if $disabled { %>disabled="disabled"<% } %> <% if $piwik_embed { %> onclick="javascript:_paq.push(['trackEvent', 'change-of-registered-office-address', 'submit-button-clicked']);"<% } %>/>
 % }
 % else {
     <input type="submit" id="<% $id %>" name="<% $name %>" value="<% $label %>" class="<% if ( $class ) { %><%$class%><% } else { %>button<% } %>" <% if $disabled { %>disabled="disabled"<% } %>/>

--- a/templates/includes/forms/transaction_submit_buttons.html.tx
+++ b/templates/includes/forms/transaction_submit_buttons.html.tx
@@ -1,5 +1,5 @@
 <div class="form-group">
-%   $form.submit_button( label => $submit_label // 'Submit', name => 'submit', id => 'submit', disabled => $disabled );
+%   $form.submit_button( label => $submit_label // 'Submit', name => 'submit', id => 'submit', disabled => $disabled, ecct_enabled => $ecct_enabled, piwik_embed => $c.config.piwik.embed );
 	<p class="action-link">
 %   $form.submit_button( label => 'Cancel', name => 'cancel', id => 'cancel', class => 'button-link' );
 	</p>


### PR DESCRIPTION
__Short description outlining key changes/additions__
Add Matomo tracking to the new AD01 appropriate office address statement checkbox (only visible when the flag FEATURE_FLAG_ENABLE_ECCT_01092023 is enabled).

With the flag set:
- it notes and tracks when the appropriate address statement checkbox has been clicked and its value is noted. 
- it notes and tracks when the Submit button has been clicked.
- it notes and tracks the error when the user has clicked Submit and the appropriate address statement checkbox is not ticked.

__JIRA Ticket Number__
ECCT-540
### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
