### PR TITLE
PAS-697 Hide address if the text shows not available

### DIFF
--- a/templates/search/results.html.tx
+++ b/templates/search/results.html.tx
@@ -69,7 +69,9 @@
                                     <p class="meta crumbtrail inset">Matching disqualification names: <br/><span><% $item.snippet %></span></p>
                                 <% } %>
                                 <p class="meta crumbtrail"><% $item.description %></p>
-                                <p><% $item.address_snippet %></p>
+                                <% if $item.address_snippet != "Not Available, Not Available, Not Available, Not Available, NOT AVAILABLE" { %>
+                                    <p><% $item.address_snippet %></p>
+                                <% } %>
                             </li>
                         % } # End-if
                     % } # Next


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/PAS-697

As part of the Sanction work, the address provided may not be available. In these cases, the addresses should be hidden from the search results page - similarly to how it's hidden in the disqualified officer page.