### PR TITLE
BI-13513 - Extend previous pre-95 logic to include PRE87, PRE87A and PRE87M type documents

### DIFF
--- a/templates/company/filing_history/view_content_certified.html.tx
+++ b/templates/company/filing_history/view_content_certified.html.tx
@@ -62,7 +62,7 @@
                       % }
                     % }
                 </td>
-                % if ($item.type != 'PRE95') && ($item.type != 'PRE95M') {
+                % if ($item.type != 'PRE95') && ($item.type != 'PRE95M') && ($item.type != 'PRE87') && ($item.type != 'PRE87A') && ($item.type != 'PRE87M') {
                     <td>
                     % if !($item._missing_message == 'unavailable') && !($item._missing_message == 'available_in_5_days') || $item.links.document_metadata  {
                         <form action="<%'/company/' ~ $company.company_number ~ '/certified-documents' %>" method="post">


### PR DESCRIPTION
Fulfils [BI-13513](https://companieshouse.atlassian.net/browse/BI-13513)

Prevent PRE-87 packages being ordered via certified copies ordering service

[BI-13513]: https://companieshouse.atlassian.net/browse/BI-13513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ