### PR TITLE
BI-13650 - Update OR to AND logic in certified document ordering

### DIFF
--- a/templates/company/filing_history/view_content_certified.html.tx
+++ b/templates/company/filing_history/view_content_certified.html.tx
@@ -64,7 +64,7 @@
                 </td>
                 % if ($item.type != 'PRE95') && ($item.type != 'PRE95M') && ($item.type != 'PRE87') && ($item.type != 'PRE87A') && ($item.type != 'PRE87M') {
                     <td>
-                    % if !($item._missing_message == 'unavailable') && !($item._missing_message == 'available_in_5_days') || $item.links.document_metadata  {
+                    % if !($item._missing_message == 'unavailable') && !($item._missing_message == 'available_in_5_days') && $item.links.document_metadata  {
                         <form action="<%'/company/' ~ $company.company_number ~ '/certified-documents' %>" method="post">
                             <input type="hidden" id="<% $item.transaction_id %>" name="transaction" value="<% $item.transaction_id %>">
                             <input type="submit" class="select-document-button-link" id="add-document-to-order-<% $item.transaction_id%>"


### PR DESCRIPTION
Fulfils [BI-13650](https://companieshouse.atlassian.net/browse/BI-13650)

Prevents 'Select Document' link from being displayed if document does not have metadata

![Screenshot 2024-05-08 at 12 33 04 (2)](https://github.com/companieshouse/ch.gov.uk/assets/95215074/1c4efa2d-1311-4e0c-8152-b7b17897e7fb)


[BI-13650]: https://companieshouse.atlassian.net/browse/BI-13650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ