### PR TITLE
BI-13628, BI-13629 - Revert accessibility changes 

### DIFF
--- a/templates/base.tx
+++ b/templates/base.tx
@@ -74,37 +74,6 @@
        main { display: block }
        }
     </style>
-
-    <!-- new styles to fix accessibility issues with numbered pagination -->
-<style type="text/css">
-
-ul.pager {
- font-size: 24px;
-}
-ul.pager li {
-box-sizing: border-box;
-    position: relative;
-    min-width: 45px;
-    min-height: 45px;
-    padding: 10px 15px;
-    float: left;
-    text-align: center;
-}
-ul.pager li.active {
-    font-weight: 700;
-    font-size: 1em;
-    outline: 1px solid #0000;
-    background-color: #1d70b8;
-    color: #fff !important;
-    text-decoration: underline;
-}
-ul.pager li:hover {
-    background-color: #f3f2f1;
-}
-.pager-a-z li.active, .pager-a-z li.inactive {
-    padding-right: 15px;
-}
-</style>
   </head>
 
   <body class="govuk-template__body">

--- a/templates/register_of_disqualifications/list.html.tx
+++ b/templates/register_of_disqualifications/list.html.tx
@@ -11,11 +11,11 @@
                 % for $alphabet -> $letter {
                     % if $active_letter == $letter {
                         <li class="active">
-                            <span id="page-1" class="page govuk-link"><%= $letter %></span>
+                            <a class="govuk-link" href="/register-of-disqualifications/<%= $letter %>" class="page"><span class="govuk-visually-hidden">Only show surnames beginning with</span><%= $letter %></a>
                         </li>
                     % } else {
                         <li class="inactive">
-                            <a class="govuk-link govuk-link--no-visited-state" href="/register-of-disqualifications/<%= $letter %>" class="page"><span class="govuk-visually-hidden">Only show surnames beginning with</span><%= $letter %></a>
+                            <a class="govuk-link" href="/register-of-disqualifications/<%= $letter %>" class="page"><span class="govuk-visually-hidden">Only show surnames beginning with</span><%= $letter %></a>
                         </li>
                     % }
                 % }

--- a/templates/search/results.html.tx
+++ b/templates/search/results.html.tx
@@ -104,28 +104,30 @@
         <ul class="pager" id="pager">
             % if ($pager.previous_page) {
                 <li>
-                    <a class="page govuk-link govuk-pagination__link govuk-link--no-visited-state" id="previous-page" href="<% $c.url_with.query([ page => $pager.previous_page ]) %>">Previous</a>
+                    <a class="page govuk-link govuk-pagination__link" id="previous-page" href="<% $c.url_with.query([ page => $pager.previous_page ]) %>">
+                        Previous
+                    </a>
                 </li>
             % }
             % for $pager.pages_in_set -> $page {
+                <li>
                     % if $page <= $pager.page_limit {
                         % if $pager.current_page == $page {
-                            <li class="active">
-                                <span class="govuk-visually-hidden">Page </span>
-                                <span id="page-<% $page %>" class="page govuk-link"><% $page %></span>
-                                <span class="govuk-visually-hidden"> of <% $pager.total_pages %></span>
-                            </li>
+                            <span class="govuk-visually-hidden">Page </span>
+                            <span id="page-<% $page %>" class="page"><% $page %></span>
+                            <span class="govuk-visually-hidden"> of <% $pager.total_pages %></span>
                         % } else {
-                            <li>
-                                <a id="page-<% $page %>" class="page govuk-link govuk-link--no-visited-state" href="<% $c.url_with.query([ page => $page ]) %>">
-                                <span class="govuk-visually-hidden">Page </span><% $page %><span class="govuk-visually-hidden"> of <% $pager.total_pages %></span></a>
-                            </li>    
+                            <a id="page-<% $page %>" class="page" href="<% $c.url_with.query([ page => $page ]) %>">
+                            <span class="govuk-visually-hidden">Page </span><% $page %><span class="govuk-visually-hidden"> of <% $pager.total_pages %></span></a>
                         % }
                     % }
+                </li>
             % }
             % if ($pager.current_page < $pager.page_limit && $pager.next_page) {
                 <li>
-                    <a class="page govuk-link govuk-pagination__link govuk-link--no-visited-state" id="next-page" href="<% $c.url_with.query([ page => $pager.next_page ]) %>">Next</a>
+                    <a class="page govuk-link govuk-pagination__link" id="next-page" href="<% $c.url_with.query([ page => $pager.next_page ]) %>">
+                        Next
+                    </a>
                 </li>
             % }
         </ul>


### PR DESCRIPTION
Reverting accessibility changes made for:
- BI-13628
- BI-13629 

This has been done as more considerations need to be made before this can progressed and to unblock BI-13686 and ECS routing changes from progressing to Staging/Live.

**Note for re-implementatoin**
The styles that were added for these stories should be moved the `cdn.ch.gov.uk` instead of being inline within the `base.tx` template.

PR's that were reverted:
https://github.com/companieshouse/ch.gov.uk/pull/463
https://github.com/companieshouse/ch.gov.uk/pull/468
https://github.com/companieshouse/ch.gov.uk/pull/469