### PR TITLE
exclude pre14s from order if metadata link exists

### DIFF
--- a/templates/company/filing_history/view_content_certified.html.tx
+++ b/templates/company/filing_history/view_content_certified.html.tx
@@ -62,7 +62,7 @@
                       % }
                     % }
                 </td>
-                % if ($item.type != 'PRE95') && ($item.type != 'PRE95M') && ($item.type != 'PRE87') && ($item.type != 'PRE87A') && ($item.type != 'PRE87M') {
+                % if ($item.type != 'PRE95') && ($item.type != 'PRE95M') && ($item.type != 'PRE87') && ($item.type != 'PRE87A') && ($item.type != 'PRE87M') && ($item.type != 'PRE14') {
                     <td>
                     % if $item.links.document_metadata  {
                         <form action="<%'/company/' ~ $company.company_number ~ '/certified-documents' %>" method="post">


### PR DESCRIPTION
Resolves [GCI-2576](https://companieshouse.atlassian.net/browse/GCI-2576)


Exclude PRE14s from being included in logic allowing for users to order images if metadata link/ image is available

[GCI-2576]: https://companieshouse.atlassian.net/browse/GCI-2576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ