### PR TITLE
Include error message in logs for a few regularly failing endpoints

### DIFF
--- a/lib/ChGovUk/Controllers/Company/Document.pm
+++ b/lib/ChGovUk/Controllers/Company/Document.pm
@@ -37,9 +37,10 @@ sub document {
                     my ($api, $tx) = @_;
 
                     $delay->emit('error', sprintf(
-                        'Failure fetching filing history item for company_number [%s] filing_history_id [%s]',
+                        'Failure fetching filing history item for company_number [%s] filing_history_id [%s] - %s',
                         $self->stash->{company_number},
                         $self->stash->{filing_history_id},
+                        $tx->error->{message}
                     ));
                 },
                 error => sub {

--- a/lib/ChGovUk/Controllers/Company/Insolvency.pm
+++ b/lib/ChGovUk/Controllers/Company/Insolvency.pm
@@ -42,10 +42,10 @@ sub view {
             $self->render;
         },
         failure => sub {
-            my ( $api, $error ) = @_;
+            my ( $api, $tx ) = @_;
 
-            error "Error retrieving company insolvency for %s: %s",
-              $self->stash('company_number'), $error;
+            error "Failure retrieving company insolvency for %s: %s",
+              $self->stash('company_number'), $tx->error->{message};
             $self->render_exception("Error retrieving company: $error");
         }
       )->execute;

--- a/lib/ChGovUk/Controllers/Company/Mortgages.pm
+++ b/lib/ChGovUk/Controllers/Company/Mortgages.pm
@@ -314,9 +314,9 @@ sub _get_image_location {
                    return $callback->($mortgage_data);
              },
                failure => sub {
-                   my ( $api, $error ) = @_;
+                   my ( $api, $tx ) = @_;
 
-                   error "Error retrieving company filing for %s: %s", $self->stash('company_number'), $error;
+                   error "Failure retrieving company filing for %s: %s", $self->stash('company_number'), $tx->error->{message};
                    return $callback->($mortgage_data);
                },
              )->execute;


### PR DESCRIPTION
Examples atm:

Failure fetching filing history item for company_number [<num>] filing_history_id [<id>] 
Error retrieving company insolvency for SC555768: Mojo::Transaction::HTTP=HASH(0x9883338) 
Error retrieving company filing for 02464002: Mojo::Transaction::HTTP=HASH(0xa2ee118) 