### PR TITLE
ASM-434 - Add checks for 404's to document controller and change error to 404

### DIFF
--- a/lib/ChGovUk/Controllers/Company/Document.pm
+++ b/lib/ChGovUk/Controllers/Company/Document.pm
@@ -39,7 +39,7 @@ sub document {
 
                     if ($code == 404) {
                         $delay->emit('not_found', sprintf(
-                            'No document_metadata_uri found for company_number [%s] filing_history_id [%s]',
+                            'Filing history item was not found for company_number [%s] filing_history_id [%s]',
                             $self->stash->{company_number},
                             $self->stash->{filing_history_id}
                         ));
@@ -135,9 +135,9 @@ sub document {
     });
 
     $delay->on(not_found => sub {
-        my ($delay, $uri) = @_;
+        my ($delay, $message) = @_;
 
-        info "[%s]: not found", $uri [DOCUMENT];
+        info "[%s]: not found", $message [DOCUMENT];
         $self->reply->not_found;
     });
 

--- a/lib/ChGovUk/Controllers/Company/Document.pm
+++ b/lib/ChGovUk/Controllers/Company/Document.pm
@@ -38,7 +38,11 @@ sub document {
                     my $code = $tx->error->{code} // 0;
 
                     if ($code == 404) {
-                        $delay->emit('not_found', $document_metadata_uri);
+                        $delay->emit('not_found', sprintf(
+                            'No document_metadata_uri found for company_number [%s] filing_history_id [%s]',
+                            $self->stash->{company_number},
+                            $self->stash->{filing_history_id}
+                        ));
                     }
                     else {
                         $delay->emit('error', sprintf(
@@ -66,7 +70,7 @@ sub document {
                         $next->($document_metadata_uri);
                     }
                     else {
-                        $delay->emit('not_found', $document_metadata_uri);
+                        $delay->emit('not_found', 'document_metadata not found in JSON');
                     }
                 },
             )->execute;


### PR DESCRIPTION
When an image is not present it is returning a 500 error in the logs. This has happened around 2 million times in the last 7 days. This PR is an attempt to address the issue that is filling the logs in live.