### PR TITLE
Updated listener enablement logic

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -16,9 +16,9 @@ locals {
   lb_listener_rule_priority_officers = 3    # officers service gets high usage so use low number for quicker rule evaluation
 
   # lb_listener_paths                  = ["*"] # TODO double check for any other services left in mesos this would take traffic away from!!!!!
-  lb_listener_paths          = ["/DISABLED-customer-feedback"]        # Remove 'DISABLED-' prefix to enable
-  lb_listener_paths_search   = ["/DISABLED-search*"]                  # Remove 'DISABLED-' prefix to enable
-  lb_listener_paths_officers = ["/company/*/officers*", "/officers*"] # Handle company officers and personal appointments
+  lb_listener_paths          = var.enable_listener ? ["*"] : ["/DISABLED-*"]
+  lb_listener_paths_search   = var.enable_listener_search ? ["/search"] : ["/DISABLED-search*"]
+  lb_listener_paths_officers = var.enable_listener_officers ? ["/company/*/officers*", "/officers*"] : ["/DISABLED-officers"]
 
   healthcheck_path           = "/healthcheck"
   healthcheck_matcher        = "200"

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -32,7 +32,6 @@ module "ecs-service-search" {
   lb_listener_arn           = data.aws_lb_listener.chgovuk_lb_listener.arn
   lb_listener_rule_priority = local.lb_listener_rule_priority_search
   lb_listener_paths         = local.lb_listener_paths_search
-  enable_listener           = var.enable_listener_search
 
   # ECS Task container health check
   use_task_container_healthcheck = true
@@ -99,7 +98,6 @@ module "ecs-service-officers" {
   lb_listener_arn           = data.aws_lb_listener.chgovuk_lb_listener.arn
   lb_listener_rule_priority = local.lb_listener_rule_priority_officers
   lb_listener_paths         = local.lb_listener_paths_officers
-  enable_listener           = var.enable_listener_officers
 
   # ECS Task container health check
   use_task_container_healthcheck = true
@@ -166,7 +164,6 @@ module "ecs-service-default" {
   lb_listener_arn           = data.aws_lb_listener.chgovuk_lb_listener.arn
   lb_listener_rule_priority = local.lb_listener_rule_priority
   lb_listener_paths         = local.lb_listener_paths
-  enable_listener           = var.enable_listener
 
   # ECS Task container health check
   use_task_container_healthcheck = true

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -2,6 +2,6 @@ environment = "cidev"
 aws_profile = "development-eu-west-2"
 
 # Listener options
-enable_listener = true
-enable_listener_search = true
+enable_listener = false
+enable_listener_search = false
 enable_listener_officers = true


### PR DESCRIPTION
Prevents an apply-time error when creating an ECS service with no listener rule but an active target group is specified.
This workaround instead always creates the listener rules but populates it the a placeholder value prefixed with `DISABLED`