### PR TITLE
Create ECS Service Dashboards

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -18,7 +18,7 @@ terraform {
 }
 
 module "ecs-service-search" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.293"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.303"
 
   # Environmental configuration
   environment             = var.environment
@@ -83,10 +83,12 @@ module "ecs-service-search" {
   eric_port                 = local.eric_port
   eric_environment_filename = local.eric_environment_filename
   eric_secrets              = []
+
+  create_service_dashboard = var.create_service_dashboard
 }
 
 module "ecs-service-officers" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.293"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.303"
 
   # Environmental configuration
   environment             = var.environment
@@ -149,10 +151,12 @@ module "ecs-service-officers" {
   eric_port                 = local.eric_port
   eric_environment_filename = local.eric_environment_filename
   eric_secrets              = []
+
+  create_service_dashboard = var.create_service_dashboard
 }
 
 module "ecs-service-default" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.293"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.303"
 
   # Environmental configuration
   environment             = var.environment
@@ -214,10 +218,12 @@ module "ecs-service-default" {
   eric_port                 = local.eric_port
   eric_environment_filename = local.eric_environment_filename
   eric_secrets              = []
+
+  create_service_dashboard = var.create_service_dashboard
 }
 
 module "secrets" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.216"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.303"
 
   name_prefix = "${local.service_name}-${var.environment}"
   environment = var.environment

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -84,7 +84,7 @@ module "ecs-service-search" {
   eric_environment_filename = local.eric_environment_filename
   eric_secrets              = []
 
-  create_service_dashboard = var.create_service_dashboard
+  create_service_dashboard = var.create_service_dashboard_search
 }
 
 module "ecs-service-officers" {
@@ -152,7 +152,7 @@ module "ecs-service-officers" {
   eric_environment_filename = local.eric_environment_filename
   eric_secrets              = []
 
-  create_service_dashboard = var.create_service_dashboard
+  create_service_dashboard = var.create_service_dashboard_officers
 }
 
 module "ecs-service-default" {

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -212,6 +212,18 @@ variable "eric_version" {
 
 variable "create_service_dashboard" {
   default     = true
-  description = "Defines whether a CloudWatch dashboard is created for the ECS service (true) or not (false)"
+  description = "Defines whether a CloudWatch dashboard is created for the default ECS service (true) or not (false)"
+  type        = bool
+}
+
+variable "create_service_dashboard_officers" {
+  default     = true
+  description = "Defines whether a CloudWatch dashboard is created for the officers ECS service (true) or not (false)"
+  type        = bool
+}
+
+variable "create_service_dashboard_search" {
+  default     = true
+  description = "Defines whether a CloudWatch dashboard is created for the search ECS service (true) or not (false)"
   type        = bool
 }

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -209,3 +209,9 @@ variable "eric_version" {
   description = "The version of the eric container to run."
   type        = string
 }
+
+variable "create_service_dashboard" {
+  default     = true
+  description = "Defines whether a CloudWatch dashboard is created for the ECS service (true) or not (false)"
+  type        = bool
+}


### PR DESCRIPTION
Bumped `ecs-service` module verisons to enable creation of CloudWatch service dashboards
Add supporting per-service vars and added required module argument.