### PR TITLE
Ensure scaling cooldowns are correctly specified

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -119,18 +119,20 @@ module "ecs-service-officers" {
   name_prefix  = local.name_prefix
 
   # Service performance and scaling configs
-  desired_task_count                 = var.desired_task_count_officers
-  min_task_count                     = var.min_task_count_officers
-  max_task_count                     = var.max_task_count_officers
-  required_cpus                      = var.required_cpus
-  required_memory                    = var.required_memory
-  service_autoscale_enabled          = var.service_autoscale_enabled
-  service_autoscale_target_value_cpu = var.service_autoscale_target_value_cpu
-  service_scaledown_schedule         = var.service_scaledown_schedule
-  service_scaleup_schedule           = var.service_scaleup_schedule
-  use_capacity_provider              = var.use_capacity_provider
-  use_fargate                        = var.use_fargate
-  fargate_subnets                    = local.application_subnet_ids
+  desired_task_count                   = var.desired_task_count_officers
+  min_task_count                       = var.min_task_count_officers
+  max_task_count                       = var.max_task_count_officers
+  required_cpus                        = var.required_cpus
+  required_memory                      = var.required_memory
+  service_autoscale_enabled            = var.service_autoscale_enabled
+  service_autoscale_target_value_cpu   = var.service_autoscale_target_value_cpu
+  service_autoscale_scale_in_cooldown  = var.service_autoscale_scale_in_cooldown
+  service_autoscale_scale_out_cooldown = var.service_autoscale_scale_out_cooldown
+  service_scaledown_schedule           = var.service_scaledown_schedule
+  service_scaleup_schedule             = var.service_scaleup_schedule
+  use_capacity_provider                = var.use_capacity_provider
+  use_fargate                          = var.use_fargate
+  fargate_subnets                      = local.application_subnet_ids
 
   # Cloudwatch
   cloudwatch_alarms_enabled = var.cloudwatch_alarms_enabled
@@ -187,18 +189,20 @@ module "ecs-service-default" {
   name_prefix  = local.name_prefix
 
   # Service performance and scaling configs
-  desired_task_count                 = var.desired_task_count
-  max_task_count                     = var.max_task_count
-  min_task_count                     = var.min_task_count
-  required_cpus                      = var.required_cpus
-  required_memory                    = var.required_memory
-  service_autoscale_enabled          = var.service_autoscale_enabled
-  service_autoscale_target_value_cpu = var.service_autoscale_target_value_cpu
-  service_scaledown_schedule         = var.service_scaledown_schedule
-  service_scaleup_schedule           = var.service_scaleup_schedule
-  use_capacity_provider              = var.use_capacity_provider
-  use_fargate                        = var.use_fargate
-  fargate_subnets                    = local.application_subnet_ids
+  desired_task_count                   = var.desired_task_count
+  max_task_count                       = var.max_task_count
+  min_task_count                       = var.min_task_count
+  required_cpus                        = var.required_cpus
+  required_memory                      = var.required_memory
+  service_autoscale_enabled            = var.service_autoscale_enabled
+  service_autoscale_target_value_cpu   = var.service_autoscale_target_value_cpu
+  service_autoscale_scale_in_cooldown  = var.service_autoscale_scale_in_cooldown
+  service_autoscale_scale_out_cooldown = var.service_autoscale_scale_out_cooldown
+  service_scaledown_schedule           = var.service_scaledown_schedule
+  service_scaleup_schedule             = var.service_scaleup_schedule
+  use_capacity_provider                = var.use_capacity_provider
+  use_fargate                          = var.use_fargate
+  fargate_subnets                      = local.application_subnet_ids
 
   # Cloudwatch
   cloudwatch_alarms_enabled = var.cloudwatch_alarms_enabled


### PR DESCRIPTION
Adds missing args to `officers` and `default` services:
- `service_autoscale_scale_in_cooldown`
- `service_autoscale_scale_out_cooldown`