### PR TITLE
Update locals.tf

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -17,7 +17,7 @@ locals {
 
   # lb_listener_paths                  = ["*"] # TODO double check for any other services left in mesos this would take traffic away from!!!!!
   lb_listener_paths          = var.enable_listener ? ["*"] : ["/DISABLED-*"]
-  lb_listener_paths_search   = var.enable_listener_search ? ["/search", "/search/disqualified-officers*", "/search/officers*", "/search/companies*"] : ["/DISABLED-search*"]
+  lb_listener_paths_search   = var.enable_listener_search ? ["/search", "/search/*"] : ["/DISABLED-search*"]
   lb_listener_paths_officers = var.enable_listener_officers ? ["/company/*/officers*", "/officers*"] : ["/DISABLED-officers"]
 
   healthcheck_path           = "/healthcheck"

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -17,7 +17,7 @@ locals {
 
   # lb_listener_paths                  = ["*"] # TODO double check for any other services left in mesos this would take traffic away from!!!!!
   lb_listener_paths          = var.enable_listener ? ["*"] : ["/DISABLED-*"]
-  lb_listener_paths_search   = var.enable_listener_search ? ["/search*"] : ["/DISABLED-search*"]
+  lb_listener_paths_search   = var.enable_listener_search ? ["/search", "/search/disqualified-officers*", "/search/officers*", "/search/companies*"] : ["/DISABLED-search*"]
   lb_listener_paths_officers = var.enable_listener_officers ? ["/company/*/officers*", "/officers*"] : ["/DISABLED-officers"]
 
   healthcheck_path           = "/healthcheck"


### PR DESCRIPTION
search.web loads it's css assets over a http request through load balancer.

Now that ch.gov.uk search is running in ECS it's higher priority than search.web.

Other options:
- Make search.web higher priority than ch.gov.uk-search
- Edit search.web assets path to something other than search*
- Actually load assets from local dir or CDN in search.web

https://cidev.aws.chdev.org/advanced-search