### PR TITLE
Re-enable listeners in cidev and staging

### DIFF
--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -2,19 +2,19 @@ environment = "cidev"
 aws_profile = "development-eu-west-2"
 
 # scaling configs default
-enable_listener = false
+enable_listener = true
 desired_task_count = 2
 min_task_count = 2
 max_task_count = 6
 
 # scaling configs search
-enable_listener_search = false
+enable_listener_search = true
 desired_task_count_search = 2
 min_task_count_search = 2
 max_task_count_search = 6
 
 # scaling configs officers
-enable_listener_officers = false
+enable_listener_officers = true
 desired_task_count_officers = 2
 min_task_count_officers = 2
 max_task_count_officers = 6

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -8,7 +8,7 @@ eric_cpus = 256
 eric_memory = 512
 
 # scaling configs default
-enable_listener = false
+enable_listener = true
 desired_task_count = 8
 min_task_count = 8
 max_task_count = 48
@@ -20,7 +20,7 @@ eric_cpus_search = 256
 eric_memory_search = 512
 
 # scaling configs search
-enable_listener_search = false
+enable_listener_search = true
 desired_task_count_search = 8
 min_task_count_search = 8
 max_task_count_search = 32
@@ -32,7 +32,7 @@ eric_cpus_officers = 256
 eric_memory_officers = 512
 
 # scaling configs officers
-enable_listener_officers = false
+enable_listener_officers = true
 desired_task_count_officers = 8
 min_task_count_officers = 8
 max_task_count_officers = 32


### PR DESCRIPTION
Re-enables the default, `officers` and `search` ALB listeners in `cidev` and `staging`

Partially resolves: DVOP-3325