### PR TITLE
Service-specific ECS Cluster & Capacity

### DIFF
--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -142,3 +142,40 @@ data "aws_kms_key" "stack_kms_officers" {
 
   key_id = "alias/${var.aws_profile}/${local.stack_kms_key_alias_officers}"
 }
+
+# ------------------------------------------------------------------------------
+# Search service ECS cluster data
+# ------------------------------------------------------------------------------
+data "vault_generic_secret" "stack_secrets_search" {
+  count = var.create_ecs_cluster_search ? 1 : 0
+
+  path = "applications/${var.aws_profile}/${var.environment}/${local.stack_fullname_search}"
+}
+
+data "aws_subnets" "stack_application_search" {
+  count = var.create_ecs_cluster_search ? 1 : 0
+
+  filter {
+    name   = "tag:Name"
+    values = [local.stack_application_subnet_pattern_search]
+  }
+  filter {
+    name   = "tag:NetworkType"
+    values = ["private"]
+  }
+}
+
+data "aws_vpc" "stack_vpc_search" {
+  count = var.create_ecs_cluster_search ? 1 : 0
+
+  filter {
+    name   = "tag:Name"
+    values = [local.stack_vpc_name_search]
+  }
+}
+
+data "aws_kms_key" "stack_kms_search" {
+  count = var.create_ecs_cluster_search ? 1 : 0
+
+  key_id = "alias/${var.aws_profile}/${local.stack_kms_key_alias_search}"
+}

--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -69,6 +69,9 @@ data "aws_ami" "ec2" {
   owners      = var.ec2_ami_owners
 }
 
+# ------------------------------------------------------------------------------
+# Default service ECS cluster data
+# ------------------------------------------------------------------------------
 data "vault_generic_secret" "stack_secrets_default" {
   count = var.create_ecs_cluster_default ? 1 : 0
 
@@ -101,4 +104,41 @@ data "aws_kms_key" "stack_kms_default" {
   count = var.create_ecs_cluster_default ? 1 : 0
 
   key_id = "alias/${var.aws_profile}/${local.stack_kms_key_alias_default}"
+}
+
+# ------------------------------------------------------------------------------
+# Officers service ECS cluster data
+# ------------------------------------------------------------------------------
+data "vault_generic_secret" "stack_secrets_officers" {
+  count = var.create_ecs_cluster_officers ? 1 : 0
+
+  path = "applications/${var.aws_profile}/${var.environment}/${local.stack_fullname_officers}"
+}
+
+data "aws_subnets" "stack_application_officers" {
+  count = var.create_ecs_cluster_officers ? 1 : 0
+
+  filter {
+    name   = "tag:Name"
+    values = [local.stack_application_subnet_pattern_officers]
+  }
+  filter {
+    name   = "tag:NetworkType"
+    values = ["private"]
+  }
+}
+
+data "aws_vpc" "stack_vpc_officers" {
+  count = var.create_ecs_cluster_officers ? 1 : 0
+
+  filter {
+    name   = "tag:Name"
+    values = [local.stack_vpc_name_officers]
+  }
+}
+
+data "aws_kms_key" "stack_kms_officers" {
+  count = var.create_ecs_cluster_officers ? 1 : 0
+
+  key_id = "alias/${var.aws_profile}/${local.stack_kms_key_alias_officers}"
 }

--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -62,3 +62,43 @@ data "aws_ssm_parameter" "global_secret" {
 data "vault_generic_secret" "shared_s3" {
   path = "aws-accounts/shared-services/s3"
 }
+
+data "aws_ami" "ec2" {
+  name_regex  = var.ec2_ami_name_regex
+  most_recent = true
+  owners      = var.ec2_ami_owners
+}
+
+data "vault_generic_secret" "stack_secrets_default" {
+  count = var.create_ecs_cluster_default ? 1 : 0
+
+  path = "applications/${var.aws_profile}/${var.environment}/${local.stack_fullname_default}"
+}
+
+data "aws_subnets" "stack_application_default" {
+  count = var.create_ecs_cluster_default ? 1 : 0
+
+  filter {
+    name   = "tag:Name"
+    values = [local.stack_application_subnet_pattern_default]
+  }
+  filter {
+    name   = "tag:NetworkType"
+    values = ["private"]
+  }
+}
+
+data "aws_vpc" "stack_vpc_default" {
+  count = var.create_ecs_cluster_default ? 1 : 0
+
+  filter {
+    name   = "tag:Name"
+    values = [local.stack_vpc_name_default]
+  }
+}
+
+data "aws_kms_key" "stack_kms_default" {
+  count = var.create_ecs_cluster_default ? 1 : 0
+
+  key_id = "alias/${var.aws_profile}/${local.stack_kms_key_alias_default}"
+}

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -93,4 +93,35 @@ locals {
   ])
 
   eric_environment_filename = "eric-web.env"
+
+  # ------------------------------------------------------------------------------
+  # ECS cluster locals
+  # ------------------------------------------------------------------------------
+  ec2_ami_id = var.ec2_ami_id == "" ? data.aws_ami.ec2.id : var.ec2_ami_id
+
+  stack_name_default        = local.service_name
+  stack_name_prefix_default = "${local.stack_name_default}-${var.environment}"
+  stack_fullname_default    = "${local.stack_name_default}-stack"
+
+  stack_secrets_default = var.create_ecs_cluster_default ? jsondecode(data.vault_generic_secret.stack_secrets_default[0].data_json) : {}
+
+  stack_application_subnet_pattern_default  = var.create_ecs_cluster_default ? local.stack_secrets_default["application_subnet_pattern"] : ""
+  stack_application_subnet_ids_default      = var.create_ecs_cluster_default ? join(",", data.aws_subnets.stack_application_default[0].ids) : ""
+  stack_kms_key_alias_default               = var.create_ecs_cluster_default ? local.stack_secrets_default["kms_key_alias"] : ""
+  stack_kms_key_id                          = var.create_ecs_cluster_default ? data.aws_kms_key.stack_kms_default[0].id : ""
+  stack_notify_topic_slack_endpoint_default = var.create_ecs_cluster_default ? local.stack_secrets_default["notify_topic_slack_endpoint"] : ""
+  stack_vpc_name_default                    = var.create_ecs_cluster_default ? local.stack_secrets_default["vpc_name"] : ""
+  stack_vpc_id_default                      = var.create_ecs_cluster_default ? data.aws_vpc.stack_vpc_default[0].id : ""
+
+  stack_parameter_store_secrets_default = var.create_ecs_cluster_default ? {
+    "web-oauth2-client-id"     = local.stack_secrets_default["web-oauth2-client-id"],
+    "web-oauth2-client-secret" = local.stack_secrets_default["web-oauth2-client-secret"],
+    "web-oauth2-cookie-secret" = local.stack_secrets_default["web-oauth2-cookie-secret"],
+    "web-oauth2-request-key"   = local.stack_secrets_default["web-oauth2-request-key"]
+  } : {}
+
+  asg_desired_instance_count_default = var.desired_task_count
+  asg_max_instance_count_default     = var.max_task_count * 2
+  asg_min_instance_count_default     = var.min_task_count
+
 }

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -95,12 +95,12 @@ locals {
   eric_environment_filename = "eric-web.env"
 
   # ------------------------------------------------------------------------------
-  # ECS cluster common locals
+  # Common ECS cluster locals
   # ------------------------------------------------------------------------------
   ec2_ami_id = var.ec2_ami_id == "" ? data.aws_ami.ec2.id : var.ec2_ami_id
 
   # ------------------------------------------------------------------------------
-  # ECS cluster default service locals
+  # Default service ECS cluster locals
   # ------------------------------------------------------------------------------
   stack_name_default        = local.service_name
   stack_name_prefix_default = "${local.stack_name_default}-${var.environment}"

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -95,10 +95,13 @@ locals {
   eric_environment_filename = "eric-web.env"
 
   # ------------------------------------------------------------------------------
-  # ECS cluster locals
+  # ECS cluster common locals
   # ------------------------------------------------------------------------------
   ec2_ami_id = var.ec2_ami_id == "" ? data.aws_ami.ec2.id : var.ec2_ami_id
 
+  # ------------------------------------------------------------------------------
+  # ECS cluster default service locals
+  # ------------------------------------------------------------------------------
   stack_name_default        = local.service_name
   stack_name_prefix_default = "${local.stack_name_default}-${var.environment}"
   stack_fullname_default    = "${local.stack_name_default}-stack"

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -117,10 +117,10 @@ locals {
   stack_vpc_id_default                      = var.create_ecs_cluster_default ? data.aws_vpc.stack_vpc_default[0].id : ""
 
   stack_parameter_store_secrets_default = var.create_ecs_cluster_default ? {
-    "web-oauth2-client-id"     = local.stack_secrets_default["web-oauth2-client-id"],
-    "web-oauth2-client-secret" = local.stack_secrets_default["web-oauth2-client-secret"],
-    "web-oauth2-cookie-secret" = local.stack_secrets_default["web-oauth2-cookie-secret"],
-    "web-oauth2-request-key"   = local.stack_secrets_default["web-oauth2-request-key"]
+    "web-oauth2-client-id"     = local.stack_secrets_default["web_oauth2_client_id"],
+    "web-oauth2-client-secret" = local.stack_secrets_default["web_oauth2_client_secret"],
+    "web-oauth2-cookie-secret" = local.stack_secrets_default["web_oauth2_cookie_secret"],
+    "web-oauth2-request-key"   = local.stack_secrets_default["web_oauth2_request_key"]
   } : {}
 
   asg_desired_instance_count_default = var.desired_task_count

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -111,7 +111,7 @@ locals {
   stack_application_subnet_pattern_default  = var.create_ecs_cluster_default ? local.stack_secrets_default["application_subnet_pattern"] : ""
   stack_application_subnet_ids_default      = var.create_ecs_cluster_default ? join(",", data.aws_subnets.stack_application_default[0].ids) : ""
   stack_kms_key_alias_default               = var.create_ecs_cluster_default ? local.stack_secrets_default["kms_key_alias"] : ""
-  stack_kms_key_id                          = var.create_ecs_cluster_default ? data.aws_kms_key.stack_kms_default[0].id : ""
+  stack_kms_key_id_default                  = var.create_ecs_cluster_default ? data.aws_kms_key.stack_kms_default[0].id : ""
   stack_notify_topic_slack_endpoint_default = var.create_ecs_cluster_default ? local.stack_secrets_default["notify_topic_slack_endpoint"] : ""
   stack_vpc_name_default                    = var.create_ecs_cluster_default ? local.stack_secrets_default["vpc_name"] : ""
   stack_vpc_id_default                      = var.create_ecs_cluster_default ? data.aws_vpc.stack_vpc_default[0].id : ""
@@ -126,5 +126,33 @@ locals {
   asg_desired_instance_count_default = var.desired_task_count
   asg_max_instance_count_default     = var.max_task_count * 2
   asg_min_instance_count_default     = var.min_task_count
+
+  # ------------------------------------------------------------------------------
+  # Officers service ECS cluster locals
+  # ------------------------------------------------------------------------------
+  stack_name_officers        = local.service_name_officers
+  stack_name_prefix_officers = "${local.stack_name_officers}-${var.environment}"
+  stack_fullname_officers    = "${local.stack_name_officers}-stack"
+
+  stack_secrets_officers = var.create_ecs_cluster_officers ? jsondecode(data.vault_generic_secret.stack_secrets_officers[0].data_json) : {}
+
+  stack_application_subnet_pattern_officers  = var.create_ecs_cluster_officers ? local.stack_secrets_officers["application_subnet_pattern"] : ""
+  stack_application_subnet_ids_officers      = var.create_ecs_cluster_officers ? join(",", data.aws_subnets.stack_application_officers[0].ids) : ""
+  stack_kms_key_alias_officers               = var.create_ecs_cluster_officers ? local.stack_secrets_officers["kms_key_alias"] : ""
+  stack_kms_key_id_officers                  = var.create_ecs_cluster_officers ? data.aws_kms_key.stack_kms_officers[0].id : ""
+  stack_notify_topic_slack_endpoint_officers = var.create_ecs_cluster_officers ? local.stack_secrets_officers["notify_topic_slack_endpoint"] : ""
+  stack_vpc_name_officers                    = var.create_ecs_cluster_officers ? local.stack_secrets_officers["vpc_name"] : ""
+  stack_vpc_id_officers                      = var.create_ecs_cluster_officers ? data.aws_vpc.stack_vpc_officers[0].id : ""
+
+  stack_parameter_store_secrets_officers = var.create_ecs_cluster_officers ? {
+    "web-oauth2-client-id"     = local.stack_secrets_officers["web_oauth2_client_id"],
+    "web-oauth2-client-secret" = local.stack_secrets_officers["web_oauth2_client_secret"],
+    "web-oauth2-cookie-secret" = local.stack_secrets_officers["web_oauth2_cookie_secret"],
+    "web-oauth2-request-key"   = local.stack_secrets_officers["web_oauth2_request_key"]
+  } : {}
+
+  asg_desired_instance_count_officers = var.desired_task_count_officers
+  asg_max_instance_count_officers     = var.max_task_count_officers * 2
+  asg_min_instance_count_officers     = var.min_task_count_officers
 
 }

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -155,4 +155,31 @@ locals {
   asg_max_instance_count_officers     = var.max_task_count_officers * 2
   asg_min_instance_count_officers     = var.min_task_count_officers
 
+  # ------------------------------------------------------------------------------
+  # Search service ECS cluster locals
+  # ------------------------------------------------------------------------------
+  stack_name_search        = local.service_name_search
+  stack_name_prefix_search = "${local.stack_name_search}-${var.environment}"
+  stack_fullname_search    = "${local.stack_name_search}-stack"
+
+  stack_secrets_search = var.create_ecs_cluster_search ? jsondecode(data.vault_generic_secret.stack_secrets_search[0].data_json) : {}
+
+  stack_application_subnet_pattern_search  = var.create_ecs_cluster_search ? local.stack_secrets_search["application_subnet_pattern"] : ""
+  stack_application_subnet_ids_search      = var.create_ecs_cluster_search ? join(",", data.aws_subnets.stack_application_search[0].ids) : ""
+  stack_kms_key_alias_search               = var.create_ecs_cluster_search ? local.stack_secrets_search["kms_key_alias"] : ""
+  stack_kms_key_id_search                  = var.create_ecs_cluster_search ? data.aws_kms_key.stack_kms_search[0].id : ""
+  stack_notify_topic_slack_endpoint_search = var.create_ecs_cluster_search ? local.stack_secrets_search["notify_topic_slack_endpoint"] : ""
+  stack_vpc_name_search                    = var.create_ecs_cluster_search ? local.stack_secrets_search["vpc_name"] : ""
+  stack_vpc_id_search                      = var.create_ecs_cluster_search ? data.aws_vpc.stack_vpc_search[0].id : ""
+
+  stack_parameter_store_secrets_search = var.create_ecs_cluster_search ? {
+    "web-oauth2-client-id"     = local.stack_secrets_search["web_oauth2_client_id"],
+    "web-oauth2-client-secret" = local.stack_secrets_search["web_oauth2_client_secret"],
+    "web-oauth2-cookie-secret" = local.stack_secrets_search["web_oauth2_cookie_secret"],
+    "web-oauth2-request-key"   = local.stack_secrets_search["web_oauth2_request_key"]
+  } : {}
+
+  asg_desired_instance_count_search = var.desired_task_count_search
+  asg_max_instance_count_search     = var.max_task_count_search * 2
+  asg_min_instance_count_search     = var.min_task_count_search
 }

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -102,7 +102,7 @@ module "ecs-service-search" {
   service_scaledown_schedule           = var.service_scaledown_schedule
   service_scaleup_schedule             = var.service_scaleup_schedule
   use_capacity_provider                = var.use_capacity_provider
-  use_fargate                          = var.use_fargate
+  use_fargate                          = var.use_fargate_search
   fargate_subnets                      = local.application_subnet_ids
 
   # Cloudwatch
@@ -172,7 +172,7 @@ module "ecs-service-officers" {
   service_scaledown_schedule           = var.service_scaledown_schedule
   service_scaleup_schedule             = var.service_scaleup_schedule
   use_capacity_provider                = var.use_capacity_provider
-  use_fargate                          = var.use_fargate
+  use_fargate                          = var.use_fargate_officers
   fargate_subnets                      = local.application_subnet_ids
 
   # Cloudwatch

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -17,6 +17,47 @@ terraform {
   backend "s3" {}
 }
 
+# ------------------------------------------------------------------------------
+# ECS cluster modules
+# ------------------------------------------------------------------------------
+module "ecs_cluster_default" {
+  count  = var.create_ecs_cluster_default ? 1 : 0
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster?ref=1.0.304"
+
+  aws_profile = var.aws_profile
+  environment = var.environment
+  name_prefix = local.stack_name_prefix_default
+  stack_name  = local.stack_name_default
+  subnet_ids  = local.stack_application_subnet_ids_default
+  vpc_id      = local.stack_vpc_id_default
+
+  asg_desired_instance_count  = local.asg_desired_instance_count_default
+  asg_max_instance_count      = local.asg_max_instance_count_default
+  asg_min_instance_count      = local.asg_min_instance_count_default
+  ec2_image_id                = local.ec2_ami_id
+  ec2_instance_type           = var.ec2_instance_type_default
+  ec2_key_pair_name           = var.ec2_key_pair_name
+  enable_asg_autoscaling      = true
+  scaledown_schedule          = var.asg_scaledown_schedule_default
+  scaleup_schedule            = var.asg_scaleup_schedule_default
+
+  enable_container_insights   = true
+  notify_topic_slack_endpoint = local.stack_notify_topic_slack_endpoint_default
+}
+
+module "cluster_secrets_default" {
+  count  = var.create_ecs_cluster_default ? 1 : 0
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.304"
+
+  environment = var.environment
+  name_prefix = local.stack_name_prefix_default
+  secrets     = local.stack_parameter_store_secrets_default
+  kms_key_id  = local.stack_kms_key_id
+}
+
+# ------------------------------------------------------------------------------
+# ECS service modules
+# ------------------------------------------------------------------------------
 module "ecs-service-search" {
   source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.304"
 

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -90,6 +90,41 @@ module "cluster_secrets_officers" {
   kms_key_id  = local.stack_kms_key_id_officers
 }
 
+module "ecs_cluster_search" {
+  count  = var.create_ecs_cluster_search ? 1 : 0
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster?ref=1.0.304"
+
+  aws_profile = var.aws_profile
+  environment = var.environment
+  name_prefix = local.stack_name_prefix_search
+  stack_name  = local.stack_name_search
+  subnet_ids  = local.stack_application_subnet_ids_search
+  vpc_id      = local.stack_vpc_id_search
+
+  asg_desired_instance_count  = local.asg_desired_instance_count_search
+  asg_max_instance_count      = local.asg_max_instance_count_search
+  asg_min_instance_count      = local.asg_min_instance_count_search
+  ec2_image_id                = local.ec2_ami_id
+  ec2_instance_type           = var.ec2_instance_type_search
+  ec2_key_pair_name           = var.ec2_key_pair_name
+  enable_asg_autoscaling      = true
+  scaledown_schedule          = var.asg_scaledown_schedule_search
+  scaleup_schedule            = var.asg_scaleup_schedule_search
+
+  enable_container_insights   = true
+  notify_topic_slack_endpoint = local.stack_notify_topic_slack_endpoint_search
+}
+
+module "cluster_secrets_search" {
+  count  = var.create_ecs_cluster_search ? 1 : 0
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.304"
+
+  environment = var.environment
+  name_prefix = local.stack_name_prefix_search
+  secrets     = local.stack_parameter_store_secrets_search
+  kms_key_id  = local.stack_kms_key_id_search
+}
+
 # ------------------------------------------------------------------------------
 # ECS service modules
 # ------------------------------------------------------------------------------

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -52,7 +52,42 @@ module "cluster_secrets_default" {
   environment = var.environment
   name_prefix = local.stack_name_prefix_default
   secrets     = local.stack_parameter_store_secrets_default
-  kms_key_id  = local.stack_kms_key_id
+  kms_key_id  = local.stack_kms_key_id_default
+}
+
+module "ecs_cluster_officers" {
+  count  = var.create_ecs_cluster_officers ? 1 : 0
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster?ref=1.0.304"
+
+  aws_profile = var.aws_profile
+  environment = var.environment
+  name_prefix = local.stack_name_prefix_officers
+  stack_name  = local.stack_name_officers
+  subnet_ids  = local.stack_application_subnet_ids_officers
+  vpc_id      = local.stack_vpc_id_officers
+
+  asg_desired_instance_count  = local.asg_desired_instance_count_officers
+  asg_max_instance_count      = local.asg_max_instance_count_officers
+  asg_min_instance_count      = local.asg_min_instance_count_officers
+  ec2_image_id                = local.ec2_ami_id
+  ec2_instance_type           = var.ec2_instance_type_officers
+  ec2_key_pair_name           = var.ec2_key_pair_name
+  enable_asg_autoscaling      = true
+  scaledown_schedule          = var.asg_scaledown_schedule_officers
+  scaleup_schedule            = var.asg_scaleup_schedule_officers
+
+  enable_container_insights   = true
+  notify_topic_slack_endpoint = local.stack_notify_topic_slack_endpoint_officers
+}
+
+module "cluster_secrets_officers" {
+  count  = var.create_ecs_cluster_officers ? 1 : 0
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.304"
+
+  environment = var.environment
+  name_prefix = local.stack_name_prefix_officers
+  secrets     = local.stack_parameter_store_secrets_officers
+  kms_key_id  = local.stack_kms_key_id_officers
 }
 
 # ------------------------------------------------------------------------------

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -19,9 +19,11 @@ enable_listener_officers = true
 desired_task_count_officers = 2
 min_task_count_officers = 2
 max_task_count_officers = 6
+use_fargate_officers = true
 
 # ------------------------------------------------------------------------------
 # ECS cluster variables
 # ------------------------------------------------------------------------------
 create_ecs_cluster_default = false
+create_ecs_cluster_officers = false
 ec2_key_pair_name = "chs-cidev"

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -6,6 +6,7 @@ enable_listener = true
 desired_task_count = 2
 min_task_count = 2
 max_task_count = 6
+use_fargate = true
 
 # scaling configs search
 enable_listener_search = true
@@ -18,3 +19,9 @@ enable_listener_officers = true
 desired_task_count_officers = 2
 min_task_count_officers = 2
 max_task_count_officers = 6
+
+# ------------------------------------------------------------------------------
+# ECS cluster variables
+# ------------------------------------------------------------------------------
+create_ecs_cluster_default = false
+ec2_key_pair_name = "chs-cidev"

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -24,6 +24,13 @@ use_fargate_officers = true
 # ------------------------------------------------------------------------------
 # ECS cluster variables
 # ------------------------------------------------------------------------------
-create_ecs_cluster_default = false
+create_ecs_cluster_default = true
+ec2_instance_type_default = "t3a.micro"
+
 create_ecs_cluster_officers = false
+ec2_instance_type_officers = "t3a.micro"
+
+create_ecs_cluster_search = false
+ec2_instance_type_search = "t3a.micro"
+
 ec2_key_pair_name = "chs-cidev"

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -371,8 +371,26 @@ variable "asg_scaleup_schedule_officers" {
 # ------------------------------------------------------------------------------
 # Search service EC2 variables
 # ------------------------------------------------------------------------------
+variable "create_ecs_cluster_search" {
+  default     = false
+  description = "Defines whether a dedicated ECS cluster should be created for the Search service (true) or not (false)"
+  type        = bool
+}
+
 variable "ec2_instance_type_search" {
   default     = "t3a.small"
   description = "The EC2 instance type to use for the Search service"
   type        = string
+}
+
+variable "asg_scaledown_schedule_search" {
+  default     = ""
+  type        = string
+  description = "The schedule to use when scaling down the number of EC2 instances to zero for the Search service ASG"
+}
+
+variable "asg_scaleup_schedule_search" {
+  default     = ""
+  type        = string
+  description = "The schedule to use when scaling up the number of EC2 instances to their normal desired level for the Search service ASG"
 }

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -319,7 +319,7 @@ variable "ec2_key_pair_name" {
 # ------------------------------------------------------------------------------
 variable "create_ecs_cluster_default" {
   default     = false
-  description = "Defines whether a dedicated ECS cluster should be created fo rthe default service (true) or not (false)"
+  description = "Defines whether a dedicated ECS cluster should be created for the default service (true) or not (false)"
   type        = bool
 }
 
@@ -344,10 +344,28 @@ variable "asg_scaleup_schedule_default" {
 # ------------------------------------------------------------------------------
 # Officers service EC2 variables
 # ------------------------------------------------------------------------------
+variable "create_ecs_cluster_officers" {
+  default     = false
+  description = "Defines whether a dedicated ECS cluster should be created for the Officers service (true) or not (false)"
+  type        = bool
+}
+
 variable "ec2_instance_type_officers" {
   default     = "t3a.small"
   description = "The EC2 instance type to use for the Officers service"
   type        = string
+}
+
+variable "asg_scaledown_schedule_officers" {
+  default     = ""
+  type        = string
+  description = "The schedule to use when scaling down the number of EC2 instances to zero for the Officers service ASG"
+}
+
+variable "asg_scaleup_schedule_officers" {
+  default     = ""
+  type        = string
+  description = "The schedule to use when scaling up the number of EC2 instances to their normal desired level for the Officers service ASG"
 }
 
 # ------------------------------------------------------------------------------

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -121,7 +121,19 @@ variable "required_memory_search" {
 
 variable "use_fargate" {
   default     = true
-  description = "If true, sets the required capabilities for all containers in the task definition to use FARGATE, false uses EC2"
+  description = "If true, sets the required capabilities for all containers in the default service task definition to use FARGATE, false uses EC2"
+  type        = bool
+}
+
+variable "use_fargate_officers" {
+  default     = true
+  description = "If true, sets the required capabilities for all containers in the Officers service task definition to use FARGATE, false uses EC2"
+  type        = bool
+}
+
+variable "use_fargate_search" {
+  default     = true
+  description = "If true, sets the required capabilities for all containers in the Search service task definition to use FARGATE, false uses EC2"
   type        = bool
 }
 
@@ -274,4 +286,75 @@ variable "create_service_dashboard_search" {
   default     = true
   description = "Defines whether a CloudWatch dashboard is created for the search ECS service (true) or not (false)"
   type        = bool
+}
+
+# ------------------------------------------------------------------------------
+# Common EC2 variables
+# ------------------------------------------------------------------------------
+variable "ec2_ami_id" {
+  default     = ""
+  description = "The AMI id to use when launching instances in the ASG; when set, will be used over the result of an AMI lookup"
+  type        = string
+}
+
+variable "ec2_ami_name_regex" {
+  default     = "^al2023-ami-ecs-hvm-2023.*-kernel-6.1-x86_64"
+  description = "The regex pattern to use to lookup an AMI when ec2_ami_id is empty"
+  type        = string
+}
+
+variable "ec2_ami_owners" {
+  default     = ["amazon"]
+  description = "A list of AWS marketplace AMI owners used to filter the AMI lookup when ec2_ami_id is empty"
+  type        = list(string)
+}
+
+variable "ec2_key_pair_name" {
+  description = "The keypair name to use when deploying EC2 instances"
+  type        = string
+}
+
+# ------------------------------------------------------------------------------
+# Default service EC2 variables
+# ------------------------------------------------------------------------------
+variable "create_ecs_cluster_default" {
+  default     = false
+  description = "Defines whether a dedicated ECS cluster should be created fo rthe default service (true) or not (false)"
+  type        = bool
+}
+
+variable "ec2_instance_type_default" {
+  default     = "t3a.small"
+  description = "The EC2 instance type to use for the default service"
+  type        = string
+}
+
+variable "asg_scaledown_schedule_default" {
+  default     = ""
+  type        = string
+  description = "The schedule to use when scaling down the number of EC2 instances to zero for the default service ASG"
+}
+
+variable "asg_scaleup_schedule_default" {
+  default     = ""
+  type        = string
+  description = "The schedule to use when scaling up the number of EC2 instances to their normal desired level for the default service ASG"
+}
+
+# ------------------------------------------------------------------------------
+# Officers service EC2 variables
+# ------------------------------------------------------------------------------
+variable "ec2_instance_type_officers" {
+  default     = "t3a.small"
+  description = "The EC2 instance type to use for the Officers service"
+  type        = string
+}
+
+# ------------------------------------------------------------------------------
+# Search service EC2 variables
+# ------------------------------------------------------------------------------
+variable "ec2_instance_type_search" {
+  default     = "t3a.small"
+  description = "The EC2 instance type to use for the Search service"
+  type        = string
 }


### PR DESCRIPTION
Adds modules to independently define ECS clusters for each service
Added data resources to lookup / retrieve data
Added supporting vars and locals
Added additional `use_fargate` vars so each service can be reconfigured independently