### PR TITLE
Cidev officers use cluster

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -183,15 +183,15 @@ locals {
   asg_max_instance_count_search     = var.max_task_count_search * 2
   asg_min_instance_count_search     = 0
 
-  ecs_cluster_id_default          = var.use_ecs_cluster_default ? module.ecs_cluster_default[0].ecs_cluster_id : data.aws_ecs_cluster.ecs_cluster.id
-  name_prefix_default             = var.use_ecs_cluster_default ? local.stack_name_prefix_default : local.name_prefix
-  task_execution_role_arn_default = var.use_ecs_cluster_default ? module.ecs_cluster_default[0].ecs_task_execution_role_arn : data.aws_iam_role.ecs_cluster_iam_role.arn
+  ecs_cluster_id_default          = var.use_ecs_cluster_default && var.create_ecs_cluster_default ? module.ecs_cluster_default[0].ecs_cluster_id : data.aws_ecs_cluster.ecs_cluster.id
+  name_prefix_default             = var.use_ecs_cluster_default && var.create_ecs_cluster_default ? local.stack_name_prefix_default : local.name_prefix
+  task_execution_role_arn_default = var.use_ecs_cluster_default && var.create_ecs_cluster_default ? module.ecs_cluster_default[0].ecs_task_execution_role_arn : data.aws_iam_role.ecs_cluster_iam_role.arn
 
-  ecs_cluster_id_officers          = var.use_ecs_cluster_officers ? module.ecs_cluster_officers[0].ecs_cluster_id : data.aws_ecs_cluster.ecs_cluster.id
-  name_prefix_officers             = var.use_ecs_cluster_officers ? local.stack_name_prefix_officers : local.name_prefix
-  task_execution_role_arn_officers = var.use_ecs_cluster_officers ? module.ecs_cluster_officers[0].ecs_task_execution_role_arn : data.aws_iam_role.ecs_cluster_iam_role.arn
+  ecs_cluster_id_officers          = var.use_ecs_cluster_officers && var.create_ecs_cluster_officers ? module.ecs_cluster_officers[0].ecs_cluster_id : data.aws_ecs_cluster.ecs_cluster.id
+  name_prefix_officers             = var.use_ecs_cluster_officers && var.create_ecs_cluster_officers ? local.stack_name_prefix_officers : local.name_prefix
+  task_execution_role_arn_officers = var.use_ecs_cluster_officers && var.create_ecs_cluster_officers ? module.ecs_cluster_officers[0].ecs_task_execution_role_arn : data.aws_iam_role.ecs_cluster_iam_role.arn
 
-  ecs_cluster_id_search          = var.use_ecs_cluster_search ? module.ecs_cluster_search[0].ecs_cluster_id : data.aws_ecs_cluster.ecs_cluster.id
-  name_prefix_search             = var.use_ecs_cluster_search ? local.stack_name_prefix_search : local.name_prefix
-  task_execution_role_arn_search = var.use_ecs_cluster_search ? module.ecs_cluster_search[0].ecs_task_execution_role_arn : data.aws_iam_role.ecs_cluster_iam_role.arn
+  ecs_cluster_id_search          = var.use_ecs_cluster_search && var.create_ecs_cluster_search ? module.ecs_cluster_search[0].ecs_cluster_id : data.aws_ecs_cluster.ecs_cluster.id
+  name_prefix_search             = var.use_ecs_cluster_search && var.create_ecs_cluster_search ? local.stack_name_prefix_search : local.name_prefix
+  task_execution_role_arn_search = var.use_ecs_cluster_search && var.create_ecs_cluster_search ? module.ecs_cluster_search[0].ecs_task_execution_role_arn : data.aws_iam_role.ecs_cluster_iam_role.arn
 }

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -182,4 +182,16 @@ locals {
   asg_desired_instance_count_search = var.desired_task_count_search
   asg_max_instance_count_search     = var.max_task_count_search * 2
   asg_min_instance_count_search     = 0
+
+  ecs_cluster_id_default          = var.use_ecs_cluster_default ? module.ecs_cluster_default[0].ecs_cluster_id : data.aws_ecs_cluster.ecs_cluster.id
+  name_prefix_default             = var.use_ecs_cluster_default ? local.stack_name_prefix_default : local.name_prefix
+  task_execution_role_arn_default = var.use_ecs_cluster_default ? module.ecs_cluster_default[0].ecs_task_execution_role_arn : data.aws_iam_role.ecs_cluster_iam_role.arn
+
+  ecs_cluster_id_officers          = var.use_ecs_cluster_officers ? module.ecs_cluster_officers[0].ecs_cluster_id : data.aws_ecs_cluster.ecs_cluster.id
+  name_prefix_officers             = var.use_ecs_cluster_officers ? local.stack_name_prefix_officers : local.name_prefix
+  task_execution_role_arn_officers = var.use_ecs_cluster_officers ? module.ecs_cluster_officers[0].ecs_task_execution_role_arn : data.aws_iam_role.ecs_cluster_iam_role.arn
+
+  ecs_cluster_id_search          = var.use_ecs_cluster_search ? module.ecs_cluster_search[0].ecs_cluster_id : data.aws_ecs_cluster.ecs_cluster.id
+  name_prefix_search             = var.use_ecs_cluster_search ? local.stack_name_prefix_search : local.name_prefix
+  task_execution_role_arn_search = var.use_ecs_cluster_search ? module.ecs_cluster_search[0].ecs_task_execution_role_arn : data.aws_iam_role.ecs_cluster_iam_role.arn
 }

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -22,7 +22,7 @@ terraform {
 # ------------------------------------------------------------------------------
 module "ecs_cluster_default" {
   count  = var.create_ecs_cluster_default ? 1 : 0
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster?ref=1.0.304"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster?ref=1.0.333"
 
   aws_profile = var.aws_profile
   environment = var.environment
@@ -47,7 +47,7 @@ module "ecs_cluster_default" {
 
 module "cluster_secrets_default" {
   count  = var.create_ecs_cluster_default ? 1 : 0
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.304"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.333"
 
   environment = var.environment
   name_prefix = local.stack_name_prefix_default
@@ -57,7 +57,7 @@ module "cluster_secrets_default" {
 
 module "ecs_cluster_officers" {
   count  = var.create_ecs_cluster_officers ? 1 : 0
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster?ref=1.0.304"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster?ref=1.0.333"
 
   aws_profile = var.aws_profile
   environment = var.environment
@@ -82,7 +82,7 @@ module "ecs_cluster_officers" {
 
 module "cluster_secrets_officers" {
   count  = var.create_ecs_cluster_officers ? 1 : 0
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.304"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.333"
 
   environment = var.environment
   name_prefix = local.stack_name_prefix_officers
@@ -92,7 +92,7 @@ module "cluster_secrets_officers" {
 
 module "ecs_cluster_search" {
   count  = var.create_ecs_cluster_search ? 1 : 0
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster?ref=1.0.304"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster?ref=1.0.333"
 
   aws_profile = var.aws_profile
   environment = var.environment
@@ -117,7 +117,7 @@ module "ecs_cluster_search" {
 
 module "cluster_secrets_search" {
   count  = var.create_ecs_cluster_search ? 1 : 0
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.304"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.333"
 
   environment = var.environment
   name_prefix = local.stack_name_prefix_search
@@ -339,7 +339,7 @@ module "ecs-service-default" {
 }
 
 module "secrets" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.304"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.333"
 
   name_prefix = "${local.service_name}-${var.environment}"
   environment = var.environment

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -206,8 +206,8 @@ module "ecs-service-officers" {
   aws_region              = var.aws_region
   aws_profile             = var.aws_profile
   vpc_id                  = data.aws_vpc.vpc.id
-  ecs_cluster_id          = data.aws_ecs_cluster.ecs_cluster.id
-  task_execution_role_arn = data.aws_iam_role.ecs_cluster_iam_role.arn
+  ecs_cluster_id          = module.ecs_cluster_officers[0].ecs_cluster_id
+  task_execution_role_arn = module.ecs_cluster_officers[0].ecs_task_execution_role_arn
 
   # Load balancer configuration
   lb_listener_arn           = data.aws_lb_listener.chgovuk_lb_listener.arn
@@ -227,7 +227,7 @@ module "ecs-service-officers" {
 
   # Service configuration
   service_name = local.service_name_officers
-  name_prefix  = local.name_prefix
+  name_prefix  = local.stack_name_prefix_officers
 
   # Service performance and scaling configs
   desired_task_count                   = var.desired_task_count_officers

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -136,8 +136,8 @@ module "ecs-service-search" {
   aws_region              = var.aws_region
   aws_profile             = var.aws_profile
   vpc_id                  = data.aws_vpc.vpc.id
-  ecs_cluster_id          = data.aws_ecs_cluster.ecs_cluster.id
-  task_execution_role_arn = data.aws_iam_role.ecs_cluster_iam_role.arn
+  ecs_cluster_id          = local.ecs_cluster_id_search
+  task_execution_role_arn = local.task_execution_role_arn_search
 
   # Load balancer configuration
   lb_listener_arn           = data.aws_lb_listener.chgovuk_lb_listener.arn
@@ -157,7 +157,7 @@ module "ecs-service-search" {
 
   # Service configuration
   service_name = local.service_name_search
-  name_prefix  = local.name_prefix
+  name_prefix  = local.name_prefix_search
 
   # Service performance and scaling configs
   desired_task_count                   = var.desired_task_count_search
@@ -206,8 +206,8 @@ module "ecs-service-officers" {
   aws_region              = var.aws_region
   aws_profile             = var.aws_profile
   vpc_id                  = data.aws_vpc.vpc.id
-  ecs_cluster_id          = module.ecs_cluster_officers[0].ecs_cluster_id
-  task_execution_role_arn = module.ecs_cluster_officers[0].ecs_task_execution_role_arn
+  ecs_cluster_id          = local.ecs_cluster_id_officers
+  task_execution_role_arn = local.task_execution_role_arn_officers
 
   # Load balancer configuration
   lb_listener_arn           = data.aws_lb_listener.chgovuk_lb_listener.arn
@@ -227,7 +227,7 @@ module "ecs-service-officers" {
 
   # Service configuration
   service_name = local.service_name_officers
-  name_prefix  = local.stack_name_prefix_officers
+  name_prefix  = local.name_prefix_officers
 
   # Service performance and scaling configs
   desired_task_count                   = var.desired_task_count_officers
@@ -276,8 +276,8 @@ module "ecs-service-default" {
   aws_region              = var.aws_region
   aws_profile             = var.aws_profile
   vpc_id                  = data.aws_vpc.vpc.id
-  ecs_cluster_id          = data.aws_ecs_cluster.ecs_cluster.id
-  task_execution_role_arn = data.aws_iam_role.ecs_cluster_iam_role.arn
+  ecs_cluster_id          = local.ecs_cluster_id_default
+  task_execution_role_arn = local.task_execution_role_arn_default
 
   # Load balancer configuration
   lb_listener_arn           = data.aws_lb_listener.chgovuk_lb_listener.arn
@@ -297,7 +297,7 @@ module "ecs-service-default" {
 
   # Service configuration
   service_name = local.service_name
-  name_prefix  = local.name_prefix
+  name_prefix  = local.name_prefix_default
 
   # Service performance and scaling configs
   desired_task_count                   = var.desired_task_count

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -14,18 +14,18 @@ desired_task_count_search = 2
 min_task_count_search = 2
 max_task_count_search = 6
 
-# scaling configs officers
-enable_listener_officers = true
-desired_task_count_officers = 2
-min_task_count_officers = 2
-max_task_count_officers = 6
-use_fargate_officers = false
-
-# officers allocation: t3a.small - 2vCPU, 2GiB RAM (-512MiB for OS)
+# Officers service configuration
 required_cpus_officers = 1536
 required_memory_officers = 1024
 eric_cpus_officers = 256
 eric_memory_officers = 512
+desired_task_count_officers = 2
+min_task_count_officers = 2
+max_task_count_officers = 6
+
+enable_listener_officers = true
+use_ecs_cluster_officers = true
+use_fargate_officers = false
 
 # ------------------------------------------------------------------------------
 # ECS cluster variables

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -19,7 +19,13 @@ enable_listener_officers = true
 desired_task_count_officers = 2
 min_task_count_officers = 2
 max_task_count_officers = 6
-use_fargate_officers = true
+use_fargate_officers = false
+
+# officers allocation: t3a.small - 2vCPU, 2GiB RAM (-512MiB for OS)
+required_cpus_officers = 1536
+required_memory_officers = 1024
+eric_cpus_officers = 256
+eric_memory_officers = 512
 
 # ------------------------------------------------------------------------------
 # ECS cluster variables

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -323,6 +323,12 @@ variable "create_ecs_cluster_default" {
   type        = bool
 }
 
+variable "use_ecs_cluster_default" {
+  default     = false
+  description = "Defines whether the dedicated ECS cluster should be used for the default service (true) or not (false)"
+  type        = bool
+}
+
 variable "ec2_instance_type_default" {
   default     = "t3a.small"
   description = "The EC2 instance type to use for the default service"
@@ -350,6 +356,12 @@ variable "create_ecs_cluster_officers" {
   type        = bool
 }
 
+variable "use_ecs_cluster_officers" {
+  default     = false
+  description = "Defines whether the dedicated ECS cluster should be used for the Officers service (true) or not (false)"
+  type        = bool
+}
+
 variable "ec2_instance_type_officers" {
   default     = "t3a.small"
   description = "The EC2 instance type to use for the Officers service"
@@ -374,6 +386,12 @@ variable "asg_scaleup_schedule_officers" {
 variable "create_ecs_cluster_search" {
   default     = false
   description = "Defines whether a dedicated ECS cluster should be created for the Search service (true) or not (false)"
+  type        = bool
+}
+
+variable "use_ecs_cluster_search" {
+  default     = false
+  description = "Defines whether the dedicated ECS cluster should be used for the Search service (true) or not (false)"
   type        = bool
 }
 


### PR DESCRIPTION
Add new vars and locals to allow per-profile use of dedicated ECS clusters
Update all ECS service modules to use new locals
Updated profile vars to set CPU and Mem and enable use of dedicated cluster for Officers service
Bump module versions