### PR TITLE
Compute Task CPU and Mem on Dedicated Cluster

### DIFF
--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -78,6 +78,10 @@ data "vault_generic_secret" "stack_secrets_default" {
   path = "applications/${var.aws_profile}/${var.environment}/${local.stack_fullname_default}"
 }
 
+data "aws_ec2_instance_type" "default" {
+  instance_type = var.ec2_instance_type_default
+}
+
 data "aws_subnets" "stack_application_default" {
   count = var.create_ecs_cluster_default ? 1 : 0
 
@@ -115,6 +119,10 @@ data "vault_generic_secret" "stack_secrets_officers" {
   path = "applications/${var.aws_profile}/${var.environment}/${local.stack_fullname_officers}"
 }
 
+data "aws_ec2_instance_type" "officers" {
+  instance_type = var.ec2_instance_type_officers
+}
+
 data "aws_subnets" "stack_application_officers" {
   count = var.create_ecs_cluster_officers ? 1 : 0
 
@@ -150,6 +158,10 @@ data "vault_generic_secret" "stack_secrets_search" {
   count = var.create_ecs_cluster_search ? 1 : 0
 
   path = "applications/${var.aws_profile}/${var.environment}/${local.stack_fullname_search}"
+}
+
+data "aws_ec2_instance_type" "search" {
+  instance_type = var.ec2_instance_type_search
 }
 
 data "aws_subnets" "stack_application_search" {

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -71,13 +71,17 @@ locals {
 
   task_secrets = concat(local.global_secret_list, local.service_secret_list, [])
 
-  task_required_memory_kb = var.required_memory * 1024
-  task_environment        = concat(local.ssm_global_version_map, local.ssm_service_version_map, [
+  task_required_cpu_default = var.use_ecs_cluster_default && var.create_ecs_cluster_default ? local.ec2_task_cpu_default : var.required_cpus
+  task_required_mem_default = var.use_ecs_cluster_default && var.create_ecs_cluster_default ? local.ec2_task_mem_default : var.required_memory
+  task_required_memory_kb   = var.required_memory * 1024
+  task_environment          = concat(local.ssm_global_version_map, local.ssm_service_version_map, [
     { "name" : "MAX_MEMORY_USAGE", "value" : "${local.task_required_memory_kb}" },
     { "name" : "PORT", "value" : "${local.container_port}" },
     { "name" : "SHARED_MEMORY_PERCENTAGE", "value" : "100" }
   ])
 
+  task_required_cpu_officers       = var.use_ecs_cluster_officers && var.create_ecs_cluster_officers ? local.ec2_task_cpu_officers : var.required_cpus_officers
+  task_required_mem_officers       = var.use_ecs_cluster_officers && var.create_ecs_cluster_officers ? local.ec2_task_mem_officers : var.required_memory_officers
   task_required_memory_kb_officers = var.required_memory_officers * 1024
   task_environment_officers        = concat(local.ssm_global_version_map, local.ssm_service_version_map, [
     { "name" : "MAX_MEMORY_USAGE", "value" : "${local.task_required_memory_kb_officers}" },
@@ -85,6 +89,8 @@ locals {
     { "name" : "SHARED_MEMORY_PERCENTAGE", "value" : "100" }
   ])
 
+  task_required_cpu_search       = var.use_ecs_cluster_search && var.create_ecs_cluster_search ? local.ec2_task_cpu_search : var.required_cpus_search
+  task_required_mem_search       = var.use_ecs_cluster_search && var.create_ecs_cluster_search ? local.ec2_task_mem_search : var.required_memory_search
   task_required_memory_kb_search = var.required_memory_search * 1024
   task_environment_search        = concat(local.ssm_global_version_map, local.ssm_service_version_map, [
     { "name" : "MAX_MEMORY_USAGE", "value" : "${local.task_required_memory_kb_search}" },
@@ -98,6 +104,9 @@ locals {
   # Common ECS cluster locals
   # ------------------------------------------------------------------------------
   ec2_ami_id = var.ec2_ami_id == "" ? data.aws_ami.ec2.id : var.ec2_ami_id
+
+  ec2_os_reserved_cpu = 128
+  ec2_os_reserved_mem = 512
 
   # ------------------------------------------------------------------------------
   # Default service ECS cluster locals
@@ -127,6 +136,15 @@ locals {
   asg_max_instance_count_default     = var.max_task_count * 2
   asg_min_instance_count_default     = 0
 
+  ecs_cluster_id_default          = var.use_ecs_cluster_default && var.create_ecs_cluster_default ? module.ecs_cluster_default[0].ecs_cluster_id : data.aws_ecs_cluster.ecs_cluster.id
+  name_prefix_default             = var.use_ecs_cluster_default && var.create_ecs_cluster_default ? local.stack_name_prefix_default : local.name_prefix
+  task_execution_role_arn_default = var.use_ecs_cluster_default && var.create_ecs_cluster_default ? module.ecs_cluster_default[0].ecs_task_execution_role_arn : data.aws_iam_role.ecs_cluster_iam_role.arn
+
+  ec2_total_cpu_default = data.aws_ec2_instance_type.default.default_vcpus * 1024
+  ec2_task_cpu_default  = local.ec2_total_cpu_default - (local.ec2_os_reserved_cpu + var.eric_cpus)
+  ec2_total_mem_default = data.aws_ec2_instance_type.default.memory_size
+  ec2_task_mem_default  = local.ec2_total_mem_default - (local.ec2_os_reserved_mem + var.eric_memory)
+
   # ------------------------------------------------------------------------------
   # Officers service ECS cluster locals
   # ------------------------------------------------------------------------------
@@ -154,6 +172,15 @@ locals {
   asg_desired_instance_count_officers = var.desired_task_count_officers
   asg_max_instance_count_officers     = var.max_task_count_officers * 2
   asg_min_instance_count_officers     = 0
+
+  ecs_cluster_id_officers          = var.use_ecs_cluster_officers && var.create_ecs_cluster_officers ? module.ecs_cluster_officers[0].ecs_cluster_id : data.aws_ecs_cluster.ecs_cluster.id
+  name_prefix_officers             = var.use_ecs_cluster_officers && var.create_ecs_cluster_officers ? local.stack_name_prefix_officers : local.name_prefix
+  task_execution_role_arn_officers = var.use_ecs_cluster_officers && var.create_ecs_cluster_officers ? module.ecs_cluster_officers[0].ecs_task_execution_role_arn : data.aws_iam_role.ecs_cluster_iam_role.arn
+
+  ec2_total_cpu_officers = data.aws_ec2_instance_type.officers.default_vcpus * 1024
+  ec2_task_cpu_officers  = local.ec2_total_cpu_officers - (local.ec2_os_reserved_cpu + var.eric_cpus_officers)
+  ec2_total_mem_officers = data.aws_ec2_instance_type.officers.memory_size
+  ec2_task_mem_officers  = local.ec2_total_mem_officers - (local.ec2_os_reserved_mem + var.eric_memory_officers)
 
   # ------------------------------------------------------------------------------
   # Search service ECS cluster locals
@@ -183,15 +210,12 @@ locals {
   asg_max_instance_count_search     = var.max_task_count_search * 2
   asg_min_instance_count_search     = 0
 
-  ecs_cluster_id_default          = var.use_ecs_cluster_default && var.create_ecs_cluster_default ? module.ecs_cluster_default[0].ecs_cluster_id : data.aws_ecs_cluster.ecs_cluster.id
-  name_prefix_default             = var.use_ecs_cluster_default && var.create_ecs_cluster_default ? local.stack_name_prefix_default : local.name_prefix
-  task_execution_role_arn_default = var.use_ecs_cluster_default && var.create_ecs_cluster_default ? module.ecs_cluster_default[0].ecs_task_execution_role_arn : data.aws_iam_role.ecs_cluster_iam_role.arn
-
-  ecs_cluster_id_officers          = var.use_ecs_cluster_officers && var.create_ecs_cluster_officers ? module.ecs_cluster_officers[0].ecs_cluster_id : data.aws_ecs_cluster.ecs_cluster.id
-  name_prefix_officers             = var.use_ecs_cluster_officers && var.create_ecs_cluster_officers ? local.stack_name_prefix_officers : local.name_prefix
-  task_execution_role_arn_officers = var.use_ecs_cluster_officers && var.create_ecs_cluster_officers ? module.ecs_cluster_officers[0].ecs_task_execution_role_arn : data.aws_iam_role.ecs_cluster_iam_role.arn
-
   ecs_cluster_id_search          = var.use_ecs_cluster_search && var.create_ecs_cluster_search ? module.ecs_cluster_search[0].ecs_cluster_id : data.aws_ecs_cluster.ecs_cluster.id
   name_prefix_search             = var.use_ecs_cluster_search && var.create_ecs_cluster_search ? local.stack_name_prefix_search : local.name_prefix
   task_execution_role_arn_search = var.use_ecs_cluster_search && var.create_ecs_cluster_search ? module.ecs_cluster_search[0].ecs_task_execution_role_arn : data.aws_iam_role.ecs_cluster_iam_role.arn
+
+  ec2_total_cpu_search = data.aws_ec2_instance_type.search.default_vcpus * 1024
+  ec2_task_cpu_search  = local.ec2_total_cpu_search - (local.ec2_os_reserved_cpu + var.eric_cpus_search)
+  ec2_total_mem_search = data.aws_ec2_instance_type.search.memory_size
+  ec2_task_mem_search  = local.ec2_total_mem_search - (local.ec2_os_reserved_mem + var.eric_memory_search)
 }

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -163,8 +163,8 @@ module "ecs-service-search" {
   desired_task_count                   = var.desired_task_count_search
   min_task_count                       = var.min_task_count_search
   max_task_count                       = var.max_task_count_search
-  required_cpus                        = var.required_cpus_search
-  required_memory                      = var.required_memory_search
+  required_cpus                        = local.task_required_cpu_search
+  required_memory                      = local.task_required_mem_search
   service_autoscale_enabled            = var.service_autoscale_enabled
   service_autoscale_target_value_cpu   = var.service_autoscale_target_value_cpu
   service_autoscale_scale_in_cooldown  = var.service_autoscale_scale_in_cooldown
@@ -233,8 +233,8 @@ module "ecs-service-officers" {
   desired_task_count                   = var.desired_task_count_officers
   min_task_count                       = var.min_task_count_officers
   max_task_count                       = var.max_task_count_officers
-  required_cpus                        = var.required_cpus_officers
-  required_memory                      = var.required_memory_officers
+  required_cpus                        = local.task_required_cpu_officers
+  required_memory                      = local.task_required_mem_officers
   service_autoscale_enabled            = var.service_autoscale_enabled
   service_autoscale_target_value_cpu   = var.service_autoscale_target_value_cpu
   service_autoscale_scale_in_cooldown  = var.service_autoscale_scale_in_cooldown
@@ -303,8 +303,8 @@ module "ecs-service-default" {
   desired_task_count                   = var.desired_task_count
   max_task_count                       = var.max_task_count
   min_task_count                       = var.min_task_count
-  required_cpus                        = var.required_cpus
-  required_memory                      = var.required_memory
+  required_cpus                        = local.task_required_cpu_default
+  required_memory                      = local.task_required_mem_default
   service_autoscale_enabled            = var.service_autoscale_enabled
   service_autoscale_target_value_cpu   = var.service_autoscale_target_value_cpu
   service_autoscale_scale_in_cooldown  = var.service_autoscale_scale_in_cooldown

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -15,10 +15,10 @@ min_task_count_search = 2
 max_task_count_search = 6
 
 # Officers service configuration
-required_cpus_officers = 1536
-required_memory_officers = 1024
-eric_cpus_officers = 256
-eric_memory_officers = 512
+# required_cpus_officers = 1536
+# required_memory_officers = 1024
+# eric_cpus_officers = 256
+# eric_memory_officers = 512
 desired_task_count_officers = 2
 min_task_count_officers = 2
 max_task_count_officers = 6


### PR DESCRIPTION
Added data lookups for the EC2 instance types for each of the clusters
Added locals to extract the instance CPU and Mem and to compute the task's CPU and memory sizing to ensure utilisation of the instance.
Updated service configurations for new locals