### PR TITLE
Enable use of dedicated clusters for default and search services

### DIFF
--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -1,18 +1,21 @@
 environment = "cidev"
 aws_profile = "development-eu-west-2"
 
-# scaling configs default
-enable_listener = true
+# Default service configuration
 desired_task_count = 2
 min_task_count = 2
 max_task_count = 6
-use_fargate = true
+enable_listener = true
+use_ecs_cluster_default = true
+use_fargate = false
 
-# scaling configs search
-enable_listener_search = true
+# Search service configuration
 desired_task_count_search = 2
 min_task_count_search = 2
 max_task_count_search = 6
+enable_listener_search = true
+use_ecs_cluster_search = true
+use_fargate_search = false
 
 # Officers service configuration
 desired_task_count_officers = 2


### PR DESCRIPTION
Updates Search and the default service to use the dedicated clusters
Switch from Fargate to EC2 capacity