### PR TITLE
Update staging to use dedicated clusters, use EC2 capacity

### DIFF
--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -1,41 +1,29 @@
 environment = "staging"
 aws_profile = "staging-eu-west-2"
 
-# default allocation
-required_cpus = 768
-required_memory = 1536
-eric_cpus = 256
-eric_memory = 512
-
-# scaling configs default
-enable_listener = true
+# Default service configuration
 desired_task_count = 8
 min_task_count = 8
 max_task_count = 48
+enable_listener = true
+use_ecs_cluster_default = true
+use_fargate = false
 
-# search allocation
-required_cpus_search = 768
-required_memory_search = 1536
-eric_cpus_search = 256
-eric_memory_search = 512
-
-# scaling configs search
-enable_listener_search = true
+# Search service configuration
 desired_task_count_search = 8
 min_task_count_search = 8
 max_task_count_search = 32
+enable_listener_search = true
+use_ecs_cluster_search = true
+use_fargate_search = false
 
-# officers allocation
-required_cpus_officers = 768
-required_memory_officers = 1536
-eric_cpus_officers = 256
-eric_memory_officers = 512
-
-# scaling configs officers
-enable_listener_officers = true
+# Officers service configuration
 desired_task_count_officers = 8
 min_task_count_officers = 8
 max_task_count_officers = 32
+enable_listener_officers = true
+use_ecs_cluster_officers = true
+use_fargate_officers = false
 
 service_autoscale_scale_out_cooldown = 120
 


### PR DESCRIPTION
Update `staging` vars to migrate services to dedicated clusters and on to EC2 capacity, rather than fargate.