### PR TITLE
Fix GOV.UK Tabs breaking when running JavaScript

### DIFF
--- a/templates/includes/company/tabs_start.tx
+++ b/templates/includes/company/tabs_start.tx
@@ -1,5 +1,5 @@
 <!-- START govuk-tabs -->
-<div class="govuk-tabs" data-module="govuk-tabs">
+<div class="govuk-tabs">
     <ul class="govuk-tabs__list">
         % include "/includes/company/tab.tx" { tabid => 'company-overview-tab', page => '', title => '<span class="govuk-visually-hidden">Company </span>Overview' }
 


### PR DESCRIPTION
With the new rebrand work we started to run the GOV.UK Frontend JavaScript code and noticed that as is, when JavaScript initialises it breaks our usage of tabs.
We have not had a problem until now because we've not initalised JavaScript, which could be considered a bug.

The GOV.UK Tabs component is typically used to change content in a single page without refreshing the page. We are using it to navigate between pages with full page refreshes. This means we do not need to initialise the JavaScript for the GOV.UK Tabs component on this page.

The `data-module` attribute tells GOV.UK Frontend to initialise the JavaScript for a component, removing this attribute makes the component HTML only.