### PR TITLE
LP-1922 Display 'update' link for Principal Place of Business

### DIFF
--- a/appconfig.yml
+++ b/appconfig.yml
@@ -56,7 +56,7 @@ external_url_for:
   certificates_url           : '<CHS_URL>/company/:company_number/orderable/certificates'
   dissolved_certificates_url : '<CHS_URL>/company/:company_number/orderable/dissolved-certificates'
   certified_copies_url       : '<CHS_URL>/company/:company_number/orderable/certified-copies'
-  update_lp_name             : '<CHS_URL>/limited-partnerships/update/company/:company_number/partnership-name'
+  update_limited_partnership : '<CHS_URL>/limited-partnerships/update/company/:company_number/:sub_url'
 
 admin_url_for:
   roles                        : <ACCOUNT_URL>/admin/roles

--- a/templates/company/view.html.tx
+++ b/templates/company/view.html.tx
@@ -61,8 +61,20 @@
         <div class="grid-row">
             <dl class="column-full">
                 <dt id="ppob-label"><% l('Principal place of business')%></dt>
-                <dd class="text data" id="ppob">
-                    % $c.address_as_string( $company.service_address, { suppress_double_commas => 1, include_care_of => 1, include_po_box => 1, title_case_care_of => 1 } );
+                <dd id="ppob" style="margin-top: 5px; margin-bottom: 10px">
+                    % my $ppob_address = $c.address_as_string( $company.service_address, { suppress_double_commas => 1, include_care_of => 1, include_po_box => 1, title_case_care_of => 1 } );
+                    <span class="text data" id="ppob-address">
+                        <% $ppob_address %>
+                    </span>
+
+                    % if ($c.is_signed_in && $company.type == 'limited-partnership' && $c.company_is_digital_lp($company.subtype)) {
+                        <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'enter-principal-place-of-business') %>" id="ppob-update-link">
+                            Update
+                            <span class="govuk-visually-hidden">
+                                Principal place of business <% $ppob_address %>
+                            </span>
+                        </a>
+                    % }
                 </dd>
             </dl>
         </div>

--- a/templates/includes/company/page_header.tx
+++ b/templates/includes/company/page_header.tx
@@ -5,7 +5,7 @@
             <h1 class="heading-xlarge" style="display: inline;"><% $company.company_name %></h1>
 
             % if ($c.is_signed_in && $company.type == 'limited-partnership' && $c.company_is_digital_lp($company.subtype)) {
-                <a href="<% $c.external_url_for('update_lp_name', company_number => $company.company_number) %>" id="update-limited-partnership-name" style="margin-left: 5px; white-space: nowrap; vertical-align: top;">Update name</a>
+                <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'partnership-name') %>" id="update-limited-partnership-name" style="margin-left: 5px; white-space: nowrap; vertical-align: top;">Update name</a>
             % }
         </div>
 


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/LP-1922

* Define a new, generic, LP post-transition update link in the application config
* Refactor existing company name 'update' link to use this new URL
* Add a new 'update' link and apply correct styling for the PPOB of a Limited Partnership
* New 'update' link also has a visually hidden text for accessibility