### PR TITLE
LP-1967 Only show LP 'update' links if user is an ACSP

### DIFF
--- a/lib/CH/Util/CompanyPrefixes.pm
+++ b/lib/CH/Util/CompanyPrefixes.pm
@@ -8,7 +8,7 @@ use vars qw(@ISA @EXPORT);
 
 @ISA = qw(Exporter);
 
-@EXPORT = qw( coAllowedOrder coFormatNumber coIsArchived coGetPrefix coIsIrish coIsAssurance coIsCompany coIsWebFiler mapSelectionToPrefix coIsLLP coIsNI coNItoUK coUKtoNI coIsRecordsHeldAtCH coIsLP coIsDigitalLP getCompanyCategory getCompanyCategoryByJurisdiction coHasNoSic);
+@EXPORT = qw( coAllowedOrder coFormatNumber coIsArchived coGetPrefix coIsIrish coIsAssurance coIsCompany coIsWebFiler mapSelectionToPrefix coIsLLP coIsNI coNItoUK coUKtoNI coIsRecordsHeldAtCH coIsLP coIsDigitalLP coIsLPUpdateAllowed getCompanyCategory getCompanyCategoryByJurisdiction coHasNoSic);
 
 #
 # ----------------------------------------------------------------------------
@@ -210,6 +210,25 @@ sub coIsDigitalLP
 {
     my $subtype=shift;
     return (($subtype eq 'lp' || $subtype eq 'slp' || $subtype eq 'pflp' || $subtype eq 'spflp') ? 1 : 0);
+}
+
+#   -----------------------------------------------------------------------------
+
+sub coIsLPUpdateAllowed
+{
+    my (%args) = @_;
+
+    my $is_signed_in    = $args{is_signed_in} ? 1 : 0;
+    my $company_type    = $args{company_type} // '';
+    my $company_subtype = $args{company_subtype} // '';
+    my $acsp_number     = $args{acsp_number};
+
+    return 0 unless $is_signed_in;
+    return 0 unless $company_type eq 'limited-partnership';
+    return 0 unless coIsDigitalLP($company_subtype);
+    return 0 unless defined $acsp_number && $acsp_number ne '';
+
+    return 1;
 }
 
 #   -----------------------------------------------------------------------------

--- a/lib/ChGovUk/Plugins/CompanyPrefixes.pm
+++ b/lib/ChGovUk/Plugins/CompanyPrefixes.pm
@@ -26,6 +26,19 @@ sub register {
         my ($c, $subtype) = @_;
         return CH::Util::CompanyPrefixes::coIsDigitalLP($subtype);
     });
+    trace "Registering %s::company_is_lp_update_allowed helper", __PACKAGE__ [APP];
+    $app->helper(company_is_lp_update_allowed => sub {
+        my ($c, $company) = @_;
+
+        my $acsp_number = $c->session->{signin_info} && $c->session->{signin_info}->{acsp_number};
+
+        return coIsLPUpdateAllowed(
+            is_signed_in    => $c->is_signed_in,
+            company_type    => $company->{type},
+            company_subtype => $company->{subtype},
+            acsp_number     => $acsp_number,
+        );
+    });
     return;
 }
 

--- a/t/unit/ChGovUk/Plugins/CompanyPrefixes.t
+++ b/t/unit/ChGovUk/Plugins/CompanyPrefixes.t
@@ -18,6 +18,7 @@ use_ok $PLUGIN;
     test_helper_company_is_llp();
     test_helper_company_has_no_sic();
     test_helper_company_is_digital_lp();
+    test_helper_company_is_lp_update_allowed();
 
 done_testing();
 
@@ -25,7 +26,7 @@ done_testing();
 
 sub test_method_register {
     subtest "Test method - register" => sub {
-        registers_helpers $PLUGIN, qw( company_is_llp company_has_no_sic company_is_digital_lp );
+        registers_helpers $PLUGIN, qw( company_is_llp company_has_no_sic company_is_digital_lp company_is_lp_update_allowed );
     };
     return;
 }
@@ -69,6 +70,80 @@ sub test_helper_company_is_digital_lp {
         is($app->controller->company_is_digital_lp(''), 0, 'Company is not a digital LP'); # Either an LP but filed with a paper LP5 OR not an LP
         is($app->controller->company_is_digital_lp('community-interest-company'), 0, 'Company is not a digital LP'); # Just not an LP
         is($app->controller->company_is_digital_lp('private-fund-limited-partnership'), 0, 'Company is not a digital LP'); # An LP but filed with a paper LP7
+    };
+    return;
+}
+
+# ==============================================================================
+
+sub test_helper_company_is_lp_update_allowed {
+    subtest "Test helper - company_is_lp_update_allowed" => sub {
+        my $controller = $app->controller;
+
+        {
+            package TestCompany;
+            sub new     { my ($class, %args) = @_; bless \%args, $class }
+            sub type    { $_[0]->{type} }
+            sub subtype { $_[0]->{subtype} }
+        }
+
+        my @cases = (
+            {
+                description  => 'allowed for a digital LP when signed in as an ACSP',
+                is_signed_in => 1,
+                acsp_number  => 'ACSP123',
+                type         => 'limited-partnership',
+                subtype      => 'lp',
+                expected     => 1,
+            },
+            {
+                description  => 'blocked when not signed in',
+                is_signed_in => 0,
+                acsp_number  => 'ACSP123',
+                type         => 'limited-partnership',
+                subtype      => 'lp',
+                expected     => 0,
+            },
+            {
+                description  => 'blocked when not an ACSP',
+                is_signed_in => 1,
+                acsp_number  => '',
+                type         => 'limited-partnership',
+                subtype      => 'lp',
+                expected     => 0,
+            },
+            {
+                description  => 'blocked for a non-LP company type',
+                is_signed_in => 1,
+                acsp_number  => 'ACSP123',
+                type         => 'ltd',
+                subtype      => '',
+                expected     => 0,
+            },
+            {
+                description  => 'blocked for a paper-filed (i.e. non-transitioned) LP',
+                is_signed_in => 1,
+                acsp_number  => 'ACSP123',
+                type         => 'limited-partnership',
+                subtype      => 'private-fund-limited-partnership',
+                expected     => 0,
+            },
+        );
+
+        no warnings 'redefine';
+        no strict 'refs';
+
+        for my $case (@cases) {
+            local *{ref($controller) . '::is_signed_in'} = sub { $case->{is_signed_in} };
+            $controller->session->{signin_info}->{acsp_number} = $case->{acsp_number};
+
+            my $company = TestCompany->new(
+                type    => $case->{type},
+                subtype => $case->{subtype},
+            );
+
+            is($controller->company_is_lp_update_allowed($company), $case->{expected}, $case->{description});
+        }
     };
     return;
 }

--- a/templates/company/view.html.tx
+++ b/templates/company/view.html.tx
@@ -46,7 +46,7 @@
                     <% $roa_address %>
                 </span>
 
-                % if ($c.is_signed_in && $company.type == 'limited-partnership' && $c.company_is_digital_lp($company.subtype)) {
+                % if ($c.company_is_lp_update_allowed($company)) {
                     <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'enter-registered-office-address') %>" id="roa-update-link">
                         Update
                         <span class="govuk-visually-hidden">
@@ -78,7 +78,7 @@
                         <% $ppob_address %>
                     </span>
 
-                    % if ($c.is_signed_in && $company.type == 'limited-partnership' && $c.company_is_digital_lp($company.subtype)) {
+                    % if ($c.company_is_lp_update_allowed($company)) {
                         <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'enter-principal-place-of-business') %>" id="ppob-update-link">
                             Update
                             <span class="govuk-visually-hidden">

--- a/templates/company/view.html.tx
+++ b/templates/company/view.html.tx
@@ -168,7 +168,7 @@
                 <span class="text data" id="company-type-value">
                     <% l($c.cv_lookup( 'company_summary', $company.type)) %>
                 </span>
-                % if ($c.is_signed_in && $company.type == 'limited-partnership' && ($company.subtype == 'lp' || $company.subtype == 'slp')) {
+                % if ($c.company_is_lp_update_allowed($company) && ($company.subtype == 'lp' || $company.subtype == 'slp')) {
                     <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'redesignate-to-pflp') %>" id="update-limited-partnership-type">
                         Update
                         <span class="govuk-visually-hidden">

--- a/templates/includes/company/page_header.tx
+++ b/templates/includes/company/page_header.tx
@@ -4,7 +4,7 @@
         <div class="company-name-row" style="margin-bottom: 10px;">
             <h1 class="heading-xlarge" style="display: inline;"><% $company.company_name %></h1>
 
-            % if ($c.is_signed_in && $company.type == 'limited-partnership' && $c.company_is_digital_lp($company.subtype)) {
+            % if ($c.company_is_lp_update_allowed($company)) {
                 <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'partnership-name') %>" id="update-limited-partnership-name" style="margin-left: 5px; white-space: nowrap; vertical-align: top;">Update name</a>
             % }
         </div>


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/LP-1967

* New helper Perl function added to check if 'update' link can be shown
* Function does all the checks that were (repeated) in the template code as well as checking for presence of an ACSP number in the session
* Template code changed to use the new function
* Unit-test added for the new Perl function