### PR TITLE
LP-1924 Display 'update' link for Company Term

### DIFF
--- a/templates/company/view.html.tx
+++ b/templates/company/view.html.tx
@@ -166,7 +166,7 @@
             <dt><% l('Company type')%></dt>
             <dd id="company-type" style="margin-top: 5px; margin-bottom: 10px">
                 <span class="text data" id="company-type-value">
-                    <% l($c.cv_lookup( 'company_summary', $company.type)) %>
+                    <% l($c.cv_lookup('company_summary', $company.type)) %>
                 </span>
                 % if ($c.company_is_lp_update_allowed($company) && ($company.subtype == 'lp' || $company.subtype == 'slp')) {
                     <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'redesignate-to-pflp') %>" id="update-limited-partnership-type">
@@ -207,7 +207,7 @@
                 <dd id="term" style="margin-top: 5px; margin-bottom: 10px">
                     % if ($company.term) {
                         <span class="text data" id="term-value">
-                            <% l('{term}', { term => $c.cv_lookup('term', $company.term) })%>
+                            <% l($term)%>
                         </span>
                     % }
 

--- a/templates/company/view.html.tx
+++ b/templates/company/view.html.tx
@@ -199,12 +199,30 @@
         </dl>
     </div>
 
-    % if (($company.subtype == 'lp' || $company.subtype == 'slp') && $company.term) {
+    % if (($company.subtype == 'lp' || $company.subtype == 'slp') && ($company.term || $c.company_is_lp_update_allowed($company))) {
         <div class="grid-row">
             <dl class="column-full">
                 <dt id="term-label"><% l('Term of the partnership')%></dt>
-                <dd class="text data" id="term">
-                    <% l('{term}', { term => $c.cv_lookup('term', $company.term) })%>
+                % my $term = $c.cv_lookup('term', $company.term);
+                <dd id="term" style="margin-top: 5px; margin-bottom: 10px">
+                    % if ($company.term) {
+                        <span class="text data" id="term-value">
+                            <% l('{term}', { term => $c.cv_lookup('term', $company.term) })%>
+                        </span>
+                    % }
+
+                    % if ($c.company_is_lp_update_allowed($company)) {
+                        <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'partnership-term') %>" id="update-limited-partnership-term">
+                            Update
+                            <span class="govuk-visually-hidden">
+                                % if ($term) {
+                                    term of partnership - <% $term %>
+                                % } else {
+                                    term of partnership
+                                % }
+                            </span>
+                        </a>
+                    % }
                 </dd>
             </dl>
         </div>


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/LP-1924

* Add a new 'update' link and apply correct styling to allow changing the term of a digitally-filed - or transitioned - Limited Partnership
* New 'update' link also has a visually hidden text for accessibility (will include current term value, if present)
* Link only shows when user is logged in and viewing an LP whose term can be changed, i.e. is an LP or SLP partnership
* Code refactored so that heading label and link will still display if no term value currently exists (but other checks pass)