### PR TITLE
LP-1572 Display LP Capital Contribution details in GCI for partners

### DIFF
--- a/lib/CH/Util/CapitalContribution.pm
+++ b/lib/CH/Util/CapitalContribution.pm
@@ -1,0 +1,28 @@
+package CH::Util::CapitalContribution;
+
+use strict;
+use warnings;
+use Exporter 'import';
+
+our @EXPORT_OK = qw(add_formatted_capital_contribution_details);
+
+sub add_formatted_capital_contribution_details {
+    my ($item, $lookup_sub_type_description) = @_;
+
+    # Only add the formatted fields if capital contribution data is present
+    return unless $item && $item->{contribution_currency_value};
+
+    # Format the amount to always have two decimal places and insert thousand separators to improve readability of large values
+    my $amount = sprintf('%.2f', $item->{contribution_currency_value});
+    1 while $amount =~ s/^(-?\d+)(\d{3})/$1,$2/;
+    $item->{contribution_currency_value_formatted} = $amount;
+
+    # Build a comma-separated list of capital contribution sub-types, from values looked up in API enumerations
+    $item->{contribution_sub_types_string} = join ', ',
+        map  { $lookup_sub_type_description->($_->{sub_type}) }
+        @{ $item->{contribution_sub_types} // [] };
+
+    return;
+}
+
+1;

--- a/lib/ChGovUk/Controllers/Company/Officers.pm
+++ b/lib/ChGovUk/Controllers/Company/Officers.pm
@@ -5,6 +5,7 @@ use Mojo::Base 'Mojolicious::Controller';
 use CH::Perl;
 use CH::Util::Pager;
 use CH::Util::DateHelper;
+use CH::Util::CapitalContribution qw(add_formatted_capital_contribution_details);
 use Locale::Simple;
 use Time::HiRes qw(tv_interval gettimeofday);
 use Scalar::Util qw(refaddr);
@@ -121,6 +122,12 @@ sub list {
                         $details->{is_identity_verification_expired} = CH::Util::DateHelper->is_current_date_greater($end_date) ? 1 : 0;
                     }
                 }
+
+                # Embellish the officer item with some formatted capital contribution details
+                add_formatted_capital_contribution_details($item, sub {
+                    my ($key) = @_;
+                    return $self->cv_lookup('capital_contribution_sub_type', $key);
+                });
             }
 
             trace "Officer list for %s: %s", $company_number, d:$results [OFFICER LIST];

--- a/lib/ChGovUk/Controllers/PersonalAppointments.pm
+++ b/lib/ChGovUk/Controllers/PersonalAppointments.pm
@@ -4,6 +4,7 @@ use Mojo::Base 'Mojolicious::Controller';
 
 use CH::Perl;
 use CH::Util::Pager;
+use CH::Util::CapitalContribution qw(add_formatted_capital_contribution_details);
 use Time::HiRes qw(tv_interval gettimeofday);
 use Scalar::Util qw(refaddr);
 
@@ -61,7 +62,13 @@ sub get {
             trace 'Appointments for officer [%s]: %s', $officer_id, d:$results;
 
             foreach my $item (@{ $results->{items} // [] }) {
-                # Skip if identity verification details are missing
+                # Embellish the appointment item with some formatted capital contribution details
+                add_formatted_capital_contribution_details($item, sub {
+                    my ($key) = @_;
+                    return $self->cv_lookup('capital_contribution_sub_type', $key);
+                });
+
+                # Skip the remaining logic if identity verification details are missing
                 my $details = $item->{identity_verification_details} or next;
 
                 # Check if identity verification expired

--- a/t/unit/CH/Util/CapitalContribution.t
+++ b/t/unit/CH/Util/CapitalContribution.t
@@ -1,0 +1,116 @@
+use strict;
+use Test::More;
+use CH::Test;
+
+use Readonly;
+Readonly my $CLASS => 'CH::Util::CapitalContribution';
+
+use_ok $CLASS;
+
+isa_ok $CLASS, 'CH::Util::CapitalContribution';
+
+methods_ok $CLASS, qw(
+    add_formatted_capital_contribution_details
+);
+
+test_returns_early_when_item_missing();
+test_returns_early_when_currency_value_missing();
+test_formats_amount_and_sub_types();
+test_empty_sub_types_array();
+
+done_testing();
+exit(0);
+
+# ==============================================================================
+
+sub test_returns_early_when_item_missing {
+    subtest "Test method add_formatted_capital_contribution_details with missing item" => sub {
+
+        my $result = CH::Util::CapitalContribution::add_formatted_capital_contribution_details(
+            undef,
+            sub { return 'ignored'; }
+        );
+
+        is($result, undef, 'Returns undef when item is missing');
+
+    };
+    return;
+}
+
+# ==============================================================================
+
+sub test_returns_early_when_currency_value_missing {
+    subtest "Test method add_formatted_capital_contribution_details with missing contribution_currency_value" => sub {
+
+        my $item = {
+            contribution_sub_types => [ { sub_type => 'money' } ],
+        };
+
+        my $result = CH::Util::CapitalContribution::add_formatted_capital_contribution_details(
+            $item,
+            sub { return 'Money'; }
+        );
+
+        is($result, undef, 'Returns undef when contribution_currency_value is missing');
+        ok(!exists $item->{contribution_currency_value_formatted}, 'Does not add contribution_currency_value_formatted');
+        ok(!exists $item->{contribution_sub_types_string}, 'Does not add contribution_sub_types_string');
+
+    };
+    return;
+}
+
+# ==============================================================================
+
+sub test_formats_amount_and_sub_types {
+    subtest "Test method add_formatted_capital_contribution_details formats values" => sub {
+
+        my $item = {
+            contribution_currency_value => 1234567.8,
+            contribution_sub_types      => [
+                { sub_type => 'money' },
+                { sub_type => 'shares' },
+            ],
+        };
+
+        my @seen_sub_types;
+        my $lookup = sub {
+            my ($sub_type) = @_;
+            push @seen_sub_types, $sub_type;
+            return 'Description for ' . $sub_type;
+        };
+
+        CH::Util::CapitalContribution::add_formatted_capital_contribution_details($item, $lookup);
+
+        is($item->{contribution_currency_value_formatted}, '1,234,567.80', 'Amount is formatted with commas and two decimal places');
+        is($item->{contribution_sub_types_string}, 'Description for money, Description for shares', 'Sub-types are joined as a comma-separated string');
+        is_deeply(\@seen_sub_types, [ 'money', 'shares' ], 'Lookup callback called for each sub_type in order');
+
+    };
+    return;
+}
+
+# ==============================================================================
+
+sub test_empty_sub_types_array {
+    subtest "Test method add_formatted_capital_contribution_details with empty sub-types" => sub {
+
+        my $item = {
+            contribution_currency_value => 1000,
+            contribution_sub_types      => [],
+        };
+
+        CH::Util::CapitalContribution::add_formatted_capital_contribution_details(
+            $item,
+            sub { return 'Should not be used'; }
+        );
+
+        is($item->{contribution_currency_value_formatted}, '1,000.00', 'Amount is formatted correctly');
+        is($item->{contribution_sub_types_string}, '', 'Empty sub-types produces empty string');
+
+    };
+    return;
+}
+
+# ==============================================================================
+
+__END__

--- a/templates/company/officers/list.html.tx
+++ b/templates/company/officers/list.html.tx
@@ -328,6 +328,18 @@
                     </dl>
                     % }
                 </div> <%# /grid-row %>
+
+                <div class="grid-row">
+                    % if $officer.contribution_currency_value {
+                        <dl class="column-quarter">
+                            <dt><% l('Capital contribution') %></dt>
+                            <dd id="officer-capital-contribution-<% $~officer.count %>" class="data">
+                                <div><% $officer.contribution_currency_value_formatted %> (<% $officer.contribution_currency_type %>)</div>
+                                <div>Types of contribution: <% $officer.contribution_sub_types_string %></div>
+                            </dd>
+                        </dl>
+                    % }
+                </div> <%# /grid-row %>
             </div>
         % }
     </div>

--- a/templates/personal_appointments/get.html.tx
+++ b/templates/personal_appointments/get.html.tx
@@ -306,6 +306,17 @@
                             % }
                         </div>
                     % }
+                    <div class="grid-row">
+                        % if $appointment.contribution_currency_value {
+                            <dl class="column-quarter">
+                                <dt><% l('Capital contribution') %></dt>
+                                <dd id="officer-capital-contribution-<% $~appointment.count %>" class="data">
+                                    <div><% $appointment.contribution_currency_value_formatted %> (<% $appointment.contribution_currency_type %>)</div>
+                                    <div>Types of contribution: <% $appointment.contribution_sub_types_string %></div>
+                                </dd>
+                            </dl>
+                        % }
+                    </div>
                 </div>
             % }
         </div>


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/LP-1572

* Enumerations updated to include new description strings
* People and appointment screen templates now include capital contribution details if present
* New utility function (file) and unit-test added to create custom, formatted output strings for capital contribution amount and list of sub-type descriptions
* Officers and Appointments controllers amended to call the new function that adds formatted output strings