### PR TITLE
CSE-1335 - No longer pass csrf_token, and changed the URL for the File Confirmation Statement button form.

### DIFF
--- a/lib/ChGovUk/Controllers/Company.pm
+++ b/lib/ChGovUk/Controllers/Company.pm
@@ -67,12 +67,7 @@ sub stash_gci_return_url {
 
     my $signInInfo = $sessRef->{signin_info};
 
-    if ($signInInfo && $signInInfo->{acsp_number} && isDigitalLP($company)) {
-      if ($sessRef->{csrf_token}) {
-          my $csrf_token = $sessRef->{csrf_token};
-          $self->stash(csrf_token => $csrf_token);
-      }
-
+    if ($signInInfo && length $signInInfo->{acsp_number} && $self->isDigitalLP($company)) {
       my $gciReturnUrl = $self->req->url->to_abs->path->to_abs_string;
 
       $sessRef->{extra_data}{gci_return_url} = $gciReturnUrl;
@@ -81,9 +76,7 @@ sub stash_gci_return_url {
 
 sub isDigitalLP {
     my ($self, $company) = @_;
-
-    return 0 unless ($company && $company->{type} eq "limited-partnership" 
-      && coIsDigitalLP($company->{subtype}));
+    return 0 unless ($company && $company->{type} eq "limited-partnership" && coIsDigitalLP($company->{subtype}));
 
     return 1;
 }

--- a/templates/company/view.html.tx
+++ b/templates/company/view.html.tx
@@ -432,8 +432,7 @@
     </div>
 
     % if ($c.company_is_lp_update_allowed($company)) {
-        <form action="/confirmation-statement/confirm-company?companyNumber=<% $company.company_number %>" method="POST">
-            <input type="hidden" name="_csrf" value="<% $csrf_token %>" />
+        <form action="/confirmation-statement/integrated-entry?companyNumber=<% $company.company_number %>" method="POST">
             <button type="submit" class="govuk-button" data-module="govuk-button" id="submit"
                 data-event-id="confirm-and-continue-button" data-govuk-button-init="">
                   File Confirmation Statement


### PR DESCRIPTION
[CSE-1335](https://companieshouse.atlassian.net/browse/CSE-1335) - No longer pass `csrf_token`, and changed the URL for the "File Confirmation Statement" button form.

[CSE-1335]: https://companieshouse.atlassian.net/browse/CSE-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ