### PR TITLE
LP-2110 Update links for active General Partners of LPs

### DIFF
--- a/lib/ChGovUk/Controllers/Company/Officers.pm
+++ b/lib/ChGovUk/Controllers/Company/Officers.pm
@@ -134,6 +134,8 @@ sub list {
                     my ($key) = @_;
                     return $self->cv_lookup('capital_contribution_sub_type', $key);
                 });
+
+                $item->{appointment_id} = extract_appointment_id($item->{links}{self});
             }
 
             trace "Officer list for %s: %s", $company_number, d:$results [OFFICER LIST];
@@ -243,6 +245,13 @@ sub build_company_appointments {
             return ' ' . $active_count . ' ' . ln('current officer ', 'current ' . $officers_label, $officer_count);
         }
     }
+}
+
+sub extract_appointment_id {
+    my ($self_link) = @_;
+    my @parts = split('/', $self_link // '');
+
+    return $parts[-1];
 }
 
 1;

--- a/t/unit/ChGovUk/Controllers/Company/Officers.t
+++ b/t/unit/ChGovUk/Controllers/Company/Officers.t
@@ -128,4 +128,21 @@ subtest "build_company_appointments returns current partners count for LPs with 
     is $result, " 2 current partners ", "should return active partner count with current partners label for LPs when active filter is set";
 };
 
+#-------------------------------------------------------------------------------
+
+subtest "extract_appointment_id returns the last path segment from a self link" => sub {
+    plan tests => 1;
+    my $result = ChGovUk::Controllers::Company::Officers::extract_appointment_id(
+        '/company/LP123456/appointments/jM-Fv2b-eo05DE8IKCDyG9fmg5s');
+    is $result, 'jM-Fv2b-eo05DE8IKCDyG9fmg5s', "should return 'jM-Fv2b-eo05DE8IKCDyG9fmg5s' as appointment_id from self link";
+};
+
+#-------------------------------------------------------------------------------
+
+subtest "extract_appointment_id returns 'undef' for when self link is undefined" => sub {
+    plan tests => 1;
+    my $result = ChGovUk::Controllers::Company::Officers::extract_appointment_id(undef);
+    is $result, undef, "should return 'undef' when self link is undefined";
+};
+
 done_testing();

--- a/templates/company/officers/list.html.tx
+++ b/templates/company/officers/list.html.tx
@@ -355,6 +355,15 @@
                     % }
                 </div> <%# /grid-row %>
             </div>
+
+            % if ($c.company_is_lp_update_allowed($company) && !$officer.resigned_on && $officer.appointment_id
+                    % && ($officer.officer_role == 'general-partner-in-a-limited-partnership' || $officer.officer_role == 'corporate-general-partner-in-a-limited-partnership')) {
+                % my $partner_sub_url = $officer.officer_role == 'corporate-general-partner-in-a-limited-partnership' ? 'update-general-partner-legal-entity' : 'update-general-partner-person';
+
+                <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'appointment/'  ~ $officer.appointment_id ~ '/' ~ $partner_sub_url) %>" id="update-limited-partnership-type">
+                    Update details for <% $officer.name %> <% $self_link %>
+                </a>
+            % }
         % }
     </div>
 

--- a/templates/company/officers/list.html.tx
+++ b/templates/company/officers/list.html.tx
@@ -361,7 +361,7 @@
                 % my $partner_sub_url = $officer.officer_role == 'corporate-general-partner-in-a-limited-partnership' ? 'update-general-partner-legal-entity' : 'update-general-partner-person';
 
                 <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'appointment/'  ~ $officer.appointment_id ~ '/' ~ $partner_sub_url) %>" id="update-limited-partnership-type">
-                    Update details for <% $officer.name %> <% $self_link %>
+                    Update details for <% $officer.name %>
                 </a>
             % }
         % }


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/LP-2110

* New 'update' hyperlinks show for active general partners - people and legal entities
* Appointment id is extracted from the office 'self' link for use in the constructed update URL
* Unit tests added