### PR TITLE
LP-2144 Record LP Post-Transition Matomo Goals for Officers

### DIFF
--- a/appconfig.yml
+++ b/appconfig.yml
@@ -77,6 +77,16 @@ piwik:
   url: "<PIWIK_URL>"
   site_id: <PIWIK_SITE_ID>
   embed: <PIWIK_EMBED>
+  lp_add_general_partner_goal_id: <PIWIK_LP_ADD_GENERAL_PARTNER_GOAL_ID>
+  lp_update_general_partner_person_goal_id: <PIWIK_LP_UPDATE_GENERAL_PARTNER_PERSON_GOAL_ID>
+  lp_update_general_partner_legal_entity_goal_id: <PIWIK_LP_UPDATE_GENERAL_PARTNER_LEGAL_ENTITY_GOAL_ID>
+  lp_remove_general_partner_person_goal_id: <PIWIK_LP_REMOVE_GENERAL_PARTNER_PERSON_GOAL_ID>
+  lp_remove_general_partner_legal_entity_goal_id: <PIWIK_LP_REMOVE_GENERAL_PARTNER_LEGAL_ENTITY_GOAL_ID>
+  lp_add_limited_partner_goal_id: <PIWIK_LP_ADD_LIMITED_PARTNER_GOAL_ID>
+  lp_update_limited_partner_person_goal_id: <PIWIK_LP_UPDATE_LIMITED_PARTNER_PERSON_GOAL_ID>
+  lp_update_limited_partner_legal_entity_goal_id: <PIWIK_LP_UPDATE_LIMITED_PARTNER_LEGAL_ENTITY_GOAL_ID>
+  lp_remove_limited_partner_person_goal_id: <PIWIK_LP_REMOVE_LIMITED_PARTNER_PERSON_GOAL_ID>
+  lp_remove_limited_partner_legal_entity_goal_id: <PIWIK_LP_REMOVE_LIMITED_PARTNER_LEGAL_ENTITY_GOAL_ID>
 
 statsd:
   host: "<STATSD_HOST>"

--- a/lib/ChGovUk/Plugins/Helpers.pm
+++ b/lib/ChGovUk/Plugins/Helpers.pm
@@ -83,6 +83,11 @@ sub _parent_url_for {
 sub _piwik_goal_id {
     my ($app, $key) = @_;
 
+    unless (exists($app->config->{piwik}{$key})) {
+        error "Cannot find goal id [%s] in config", $key [HELPERS];
+        return;
+    }
+
     return $app->config->{piwik}{$key};
 }
 

--- a/lib/ChGovUk/Plugins/Helpers.pm
+++ b/lib/ChGovUk/Plugins/Helpers.pm
@@ -11,6 +11,7 @@ sub register {
     $app->helper(base_url         => \&_base_url);
     $app->helper(external_url_for => \&_external_url_for);
     $app->helper(parent_url_for   => \&_parent_url_for);
+    $app->helper(piwik_goal_id    => \&_piwik_goal_id);
 
 	# Helper to return the current URL for a different language
     $app->helper(url_for_lang => sub {
@@ -77,6 +78,13 @@ sub _parent_url_for {
     return $url_for;
 }
 
+# -----------------------------------------------------------------------------
+
+sub _piwik_goal_id {
+    my ($app, $key) = @_;
+
+    return $app->config->{piwik}{$key};
+}
 
 1;
 

--- a/t/unit/ChGovUk/Plugins/Helpers.t
+++ b/t/unit/ChGovUk/Plugins/Helpers.t
@@ -1,0 +1,46 @@
+use strict;
+use Test::More;
+use CH::Test;
+
+use Readonly;
+Readonly my $PLUGIN => 'ChGovUk::Plugins::Helpers';
+
+use_ok $PLUGIN;
+new_ok $PLUGIN;
+
+methods_ok $PLUGIN, qw(register);
+
+my $app = get_fake_app;
+$app->plugin($PLUGIN);
+
+test_method_register();
+test_helper_piwik_goal_id();
+
+done_testing();
+
+# ==============================================================================
+
+sub test_method_register {
+    subtest "Test method - register" => sub {
+        registers_helpers $PLUGIN, qw(
+            base_url external_url_for parent_url_for piwik_goal_id url_for_lang
+        );
+    };
+    return;
+}
+
+# ------------------------------------------------------------------------------
+
+sub test_helper_piwik_goal_id {
+    subtest "Test helper - piwik_goal_id" => sub {
+        my $ctrl = $app->controller;
+
+        $app->config({ piwik => { lp_add_general_partner_goal_id => 33 } });
+
+        is($ctrl->piwik_goal_id('lp_add_general_partner_goal_id'), 33, 'returns goal id for a defined key');
+        is($ctrl->piwik_goal_id('unknown_id_key'), undef, 'returns undef for an unknown key');
+    };
+    return;
+}
+
+# ==============================================================================

--- a/templates/company/officers/list.html.tx
+++ b/templates/company/officers/list.html.tx
@@ -12,9 +12,25 @@
 
     % if ($c.company_is_lp_update_allowed($company)) {
         <div class="govuk-button-group">
-            <a class="govuk-button govuk-button--secondary" href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'general-partner-type') %>" id="add-general-partner">Add a general partner</a>
+            <a class="govuk-button govuk-button--secondary"
+                href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'general-partner-type') %>"
+                id="add-general-partner"
+                % if $c.config.piwik.embed {
+                    onclick="javascript:_paq.push(['trackGoal', <% $c.config.piwik.lp_add_general_partner_goal_id %>]);"
+                % }
+            >
+                Add a general partner
+            </a>
 
-            <a class="govuk-button govuk-button--secondary" href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'limited-partner-type') %>" id="add-limited-partner">Add a limited partner</a>
+            <a class="govuk-button govuk-button--secondary"
+                href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'limited-partner-type') %>"
+                id="add-limited-partner"
+                % if $c.config.piwik.embed {
+                    onclick="javascript:_paq.push(['trackGoal', <% $c.config.piwik.lp_add_limited_partner_goal_id %>]);"
+                % }
+            >
+                Add a limited partner
+            </a>
         </div>
     % }
 
@@ -372,13 +388,30 @@
                 %       $officer.officer_role == 'limited-partner-in-a-limited-partnership' ? 'limited-partner-person' : '';
 
                 % if ($partner_type) {
-                    <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'appointment/' ~ $officer.appointment_id ~ '/update-' ~ $partner_type) %>" id="update-limited-partnership-partner-<% $~officer.count %>">
+                    % my $partner_type_with_underscores = $officer.officer_role == 'corporate-general-partner-in-a-limited-partnership' ? 'general_partner_legal_entity' :
+                    %       $officer.officer_role == 'general-partner-in-a-limited-partnership' ? 'general_partner_person' :
+                    %       $officer.officer_role == 'corporate-limited-partner-in-a-limited-partnership' ? 'limited_partner_legal_entity' :
+                    %       $officer.officer_role == 'limited-partner-in-a-limited-partnership' ? 'limited_partner_person' : '';
+
+                    <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'appointment/' ~ $officer.appointment_id ~ '/update-' ~ $partner_type) %>"
+                        id="update-limited-partnership-partner-<% $~officer.count %>"
+                        % if $c.config.piwik.embed {
+                            % my $update_goal_key = "lp_update_" ~ $partner_type_with_underscores ~ "_goal_id";
+                            onclick="javascript:_paq.push(['trackGoal', <% $c.piwik_goal_id($update_goal_key) %>]);"
+                        % }
+                    >
                         Update details for <% $officer.name %>
                     </a>
 
                     <br><br>
 
-                    <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'appointment/' ~ $officer.appointment_id ~ '/when-did-the-' ~ $partner_type ~ '-cease') %>" id="remove-limited-partnership-partner-<% $~officer.count %>">
+                    <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'appointment/' ~ $officer.appointment_id ~ '/when-did-the-' ~ $partner_type ~ '-cease') %>"
+                        id="remove-limited-partnership-partner-<% $~officer.count %>"
+                        % if $c.config.piwik.embed {
+                            % my $remove_goal_key = "lp_remove_" ~ $partner_type_with_underscores ~ "_goal_id";
+                            onclick="javascript:_paq.push(['trackGoal', <% $c.piwik_goal_id($remove_goal_key) %>]);"
+                        % }
+                    >
                         Remove <% $officer.name %>
                     </a>
                 % }

--- a/templates/company/officers/list.html.tx
+++ b/templates/company/officers/list.html.tx
@@ -16,7 +16,7 @@
                 href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'general-partner-type') %>"
                 id="add-general-partner"
                 % if $c.config.piwik.embed {
-                    onclick="javascript:_paq.push(['trackGoal', <% $c.config.piwik.lp_add_general_partner_goal_id %>]);"
+                    onclick="javascript:_paq.push(['trackGoal', <% $c.piwik_goal_id('lp_add_general_partner_goal_id') %>]);"
                 % }
             >
                 Add a general partner
@@ -26,7 +26,7 @@
                 href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'limited-partner-type') %>"
                 id="add-limited-partner"
                 % if $c.config.piwik.embed {
-                    onclick="javascript:_paq.push(['trackGoal', <% $c.config.piwik.lp_add_limited_partner_goal_id %>]);"
+                    onclick="javascript:_paq.push(['trackGoal', <% $c.piwik_goal_id('lp_add_limited_partner_goal_id') %>]);"
                 % }
             >
                 Add a limited partner


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/LP-2144

* Goal ids read from config to ensure that they can vary between environments
* Perl helper function added to allow dynamic creation of the config key
* Unit-test for function added
* Template updates to record the goal in Matomo when user clicks on the officer buttons and links