### PR TITLE
LP-2149 Record LP Post-Transition Matomo Goals for Company Details

### DIFF
--- a/appconfig.yml
+++ b/appconfig.yml
@@ -87,6 +87,11 @@ piwik:
   lp_update_limited_partner_legal_entity_goal_id: <PIWIK_LP_UPDATE_LIMITED_PARTNER_LEGAL_ENTITY_GOAL_ID>
   lp_remove_limited_partner_person_goal_id: <PIWIK_LP_REMOVE_LIMITED_PARTNER_PERSON_GOAL_ID>
   lp_remove_limited_partner_legal_entity_goal_id: <PIWIK_LP_REMOVE_LIMITED_PARTNER_LEGAL_ENTITY_GOAL_ID>
+  lp_update_name: <PIWIK_LP_UPDATE_NAME>
+  lp_update_registered_office_address: <PIWIK_LP_UPDATE_REGISTERED_OFFICE_ADDRESS>
+  lp_update_principal_office_address: <PIWIK_LP_UPDATE_PRINCIPAL_OFFICE_ADDRESS>
+  lp_update_type: <PIWIK_LP_UPDATE_TYPE>
+  lp_update_term: <PIWIK_LP_UPDATE_TERM>
 
 statsd:
   host: "<STATSD_HOST>"

--- a/templates/company/view.html.tx
+++ b/templates/company/view.html.tx
@@ -47,7 +47,12 @@
                 </span>
 
                 % if ($c.company_is_lp_update_allowed($company)) {
-                    <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'enter-registered-office-address') %>" id="roa-update-link">
+                    <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'enter-registered-office-address') %>"
+                        id="roa-update-link"
+                        % if $c.config.piwik.embed {
+                            onclick="javascript:_paq.push(['trackGoal', <% $c.piwik_goal_id('lp_update_registered_office_address') %>]);"
+                        % }
+                    >
                         Update
                         <span class="govuk-visually-hidden">
                             Registered office address <% $roa_address %>
@@ -79,7 +84,12 @@
                     </span>
 
                     % if ($c.company_is_lp_update_allowed($company)) {
-                        <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'enter-principal-place-of-business') %>" id="ppob-update-link">
+                        <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'enter-principal-place-of-business') %>"
+                            id="ppob-update-link"
+                            % if $c.config.piwik.embed {
+                                onclick="javascript:_paq.push(['trackGoal', <% $c.piwik_goal_id('lp_update_principal_office_address') %>]);"
+                            % }
+                        >
                             Update
                             <span class="govuk-visually-hidden">
                                 Principal place of business <% $ppob_address %>
@@ -169,7 +179,12 @@
                     <% l($c.cv_lookup('company_summary', $company.type)) %>
                 </span>
                 % if ($c.company_is_lp_update_allowed($company) && ($company.subtype == 'lp' || $company.subtype == 'slp')) {
-                    <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'redesignate-to-pflp') %>" id="update-limited-partnership-type">
+                    <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'redesignate-to-pflp') %>"
+                        id="update-limited-partnership-type"
+                        % if $c.config.piwik.embed {
+                            onclick="javascript:_paq.push(['trackGoal', <% $c.piwik_goal_id('lp_update_type') %>]);"
+                        % }
+                    >
                         Update
                         <span class="govuk-visually-hidden">
                             and apply for designation as a private fund limited partnership (PFLP)
@@ -212,7 +227,12 @@
                     % }
 
                     % if ($c.company_is_lp_update_allowed($company)) {
-                        <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'partnership-term') %>" id="update-limited-partnership-term">
+                        <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'partnership-term') %>"
+                            id="update-limited-partnership-term"
+                            % if $c.config.piwik.embed {
+                                onclick="javascript:_paq.push(['trackGoal', <% $c.piwik_goal_id('lp_update_term') %>]);"
+                            % }
+                        >
                             Update
                             <span class="govuk-visually-hidden">
                                 % if ($term) {
@@ -383,7 +403,7 @@
                 </p>
             % }
             <dl>
-        % } 
+        % }
         % else {
             <div class="column-half">
                 % if $company.confirmation_statement.overdue == 1 {

--- a/templates/includes/company/page_header.tx
+++ b/templates/includes/company/page_header.tx
@@ -5,7 +5,14 @@
             <h1 class="heading-xlarge" style="display: inline;"><% $company.company_name %></h1>
 
             % if ($c.company_is_lp_update_allowed($company)) {
-                <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'partnership-name') %>" id="update-limited-partnership-name" style="margin-left: 5px; white-space: nowrap; vertical-align: top;">Update name</a>
+                <a href="<% $c.external_url_for('update_limited_partnership', company_number => $company.company_number, sub_url => 'partnership-name') %>"
+                    id="update-limited-partnership-name" style="margin-left: 5px; white-space: nowrap; vertical-align: top;"
+                    % if $c.config.piwik.embed {
+                        onclick="javascript:_paq.push(['trackGoal', <% $c.piwik_goal_id('lp_update_name') %>]);"
+                    % }
+                >
+                    Update name
+                </a>
             % }
         </div>
 


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/LP-2149

* Goal ids read from config to ensure that they can vary between environments
* Template updates to record the goal in Matomo when user clicks on the various update links